### PR TITLE
Added 'Spark Error' termination code.

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/TerminationCode.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/TerminationCode.cs
@@ -76,6 +76,11 @@ namespace Microsoft.Azure.Databricks.Client
         /// <summary>
         /// The Azure Databricks trial subscription expired.
         /// </summary>
-        TRIAL_EXPIRED
+        TRIAL_EXPIRED,
+
+        /// <summary>
+        /// Databricks driver may be down, resulting in a spark error.
+        /// </summary>
+        SPARK_ERROR
     }
 }


### PR DESCRIPTION
When creating a spark cluster in Databricks, the driver may have been shut down unexpectedly, e.g
```
{
...
 "state": "TERMINATED",
            "state_message": "Spark encountered an error during startup. databricks_error_message: Spark error: Driver down"
}
```

The termination code is as follows:

```
           "termination_reason": {
                "code": "SPARK_ERROR",
                "parameters": {
                    "databricks_error_message": "Spark error: Driver down"
                }
            }
```