### PR TITLE
Introduce `Run.IsCompleted` & `Run.EndTime`

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/Run.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Run.cs
@@ -100,5 +100,29 @@ namespace Microsoft.Azure.Databricks.Client
         /// </summary>
         [JsonProperty(PropertyName = "run_page_url")]
         public string RunPageUrl { get; set; }
+
+        /// <summary>
+        /// The time at which this run was finished in epoch milliseconds (milliseconds since 1/1/1970 UTC).
+        /// </summary>
+        [JsonProperty(PropertyName = "start_time")]
+        [JsonConverter(typeof(MillisecondEpochDateTimeConverter))]
+        public DateTimeOffset? EndTime
+        {
+            get
+            {
+                if (StartTime.HasValue == false)
+                {
+                    return null;
+                }
+
+                var setupDuration = TimeSpan.FromMilliseconds(SetupDuration);
+                var cleanupDuration = TimeSpan.FromMilliseconds(CleanupDuration);
+                var executionDuration = TimeSpan.FromMilliseconds(ExecutionDuration);
+
+                var jobExecution = setupDuration.Add(cleanupDuration).Add(executionDuration);
+
+                return StartTime.Value.Add(jobExecution);
+            }
+        }
     }
 }

--- a/csharp/Microsoft.Azure.Databricks.Client/Run.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Run.cs
@@ -104,8 +104,7 @@ namespace Microsoft.Azure.Databricks.Client
         /// <summary>
         /// The time at which this run was finished in epoch milliseconds (milliseconds since 1/1/1970 UTC).
         /// </summary>
-        [JsonProperty(PropertyName = "start_time")]
-        [JsonConverter(typeof(MillisecondEpochDateTimeConverter))]
+        [JsonIgnore]
         public DateTimeOffset? EndTime
         {
             get

--- a/csharp/Microsoft.Azure.Databricks.Client/Run.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Run.cs
@@ -102,6 +102,12 @@ namespace Microsoft.Azure.Databricks.Client
         public string RunPageUrl { get; set; }
 
         /// <summary>
+        /// Indication if the run has been completed.
+        /// </summary>
+        [JsonIgnore]
+        public bool IsCompleted => State?.ResultState != null;
+
+        /// <summary>
         /// The time at which this run was finished in epoch milliseconds (milliseconds since 1/1/1970 UTC).
         /// </summary>
         [JsonIgnore]
@@ -109,7 +115,7 @@ namespace Microsoft.Azure.Databricks.Client
         {
             get
             {
-                if (StartTime.HasValue == false)
+                if (StartTime.HasValue == false || IsCompleted == false)
                 {
                     return null;
                 }


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

Introduce `Run.EndTime` which is a calculated property based on [official docs](https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/jobs?toc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fazure-databricks%2FTOC.json&bc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#--run)

Relates to #24