### PR TITLE
Add support for pausing and unpausing in job schedules

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/CronSchedule.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/CronSchedule.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System.ComponentModel;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Microsoft.Azure.Databricks.Client
 {
@@ -19,7 +21,9 @@ namespace Microsoft.Azure.Databricks.Client
         /// <summary>
         /// Indicate whether this schedule is paused or not.
         /// </summary>
+        [DefaultValue(PauseStatus.UNPAUSED)]
         [JsonProperty(PropertyName = "pause_status")]
+        [JsonConverter(typeof(StringEnumConverter))]
         public PauseStatus PauseStatus { get; set; }
     }
 

--- a/csharp/Microsoft.Azure.Databricks.Client/CronSchedule.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/CronSchedule.cs
@@ -15,5 +15,27 @@ namespace Microsoft.Azure.Databricks.Client
         /// </summary>
         [JsonProperty(PropertyName = "timezone_id")]
         public string TimezoneId { get; set; }
+
+        /// <summary>
+        /// Indicate whether this schedule is paused or not.
+        /// </summary>
+        [JsonProperty(PropertyName = "pause_status")]
+        public PauseStatus PauseStatus { get; set; }
+    }
+
+    /// <summary>
+    /// The paused status for a cron schedule
+    /// </summary>
+    public enum PauseStatus
+    {
+        /// <summary>
+        /// Set when the cron schedule is paused
+        /// </summary>
+        PAUSED,
+        
+        /// <summary>
+        /// Set when the cron schedule is not paused
+        /// </summary>
+        UNPAUSED
     }
 }

--- a/csharp/Microsoft.Azure.Databricks.Client/JobSettings.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/JobSettings.cs
@@ -50,6 +50,17 @@ namespace Microsoft.Azure.Databricks.Client
         }
 
         /// <summary>
+        /// Adds a cron schedule to a job
+        /// </summary>
+        /// <param name="cronSchedule"></param>
+        /// <returns></returns>
+        public JobSettings WithSchedule(CronSchedule cronSchedule)
+        {
+            this.Schedule = cronSchedule;
+            return this;
+        }
+
+        /// <summary>
         /// An optional name for the job. The default value is Untitled.
         /// </summary>
         [JsonProperty(PropertyName = "name")]


### PR DESCRIPTION
Adds support for the pause_status response in the cron schedule. Also added in a new `WithSchedule` method (so as not to change the public API of existing methods) to the `JobSettings` class to allow setting the schedule for a job, and added in some example code using this in `program.cs` in the samples folder.

I'm just testing this against our test databricks workspace internally now, but I believe I've followed the same patterns as the rest of the repo so hopefully this is fine. If you would prefer I can remove the sample code, I just thought it would be nice to add in more usage examples :)