### PR TITLE
Permissions Api

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/AclPermissionDescription.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/AclPermissionDescription.cs
@@ -1,0 +1,14 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Microsoft.Azure.Databricks.Client
+{
+    public class AclPermissionDescription
+    {
+        [JsonProperty("permission_level")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public PermissionLevel PermissionLevel { get; set; }
+
+        public string Description { get; set; }
+    }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/AclPermissionItem.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/AclPermissionItem.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Microsoft.Azure.Databricks.Client
 {
@@ -10,13 +12,13 @@ namespace Microsoft.Azure.Databricks.Client
         /// <summary>
         /// The principal to which the permission is applied. This field is required.
         /// </summary>
-        public string Principal { get; set; }
+        public virtual string Principal { get; set; }
 
         /// <summary>
         /// The permission level applied to the principal. This field is required.
         /// </summary>
-        public PermissionLevel Permission { get; set; }
-
-        internal abstract Dictionary<string,string> ToDictionaryRepresentation();
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty("permission_level")]
+        public virtual PermissionLevel Permission { get; set; }
     }
 }

--- a/csharp/Microsoft.Azure.Databricks.Client/AclPermissionItem.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/AclPermissionItem.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.Databricks.Client
+{
+    /// <summary>
+    /// An abstract item representing an ACL rule for an object. To be used with the permissions API
+    /// </summary>
+    public abstract class AclPermissionItem
+    {
+        /// <summary>
+        /// The principal to which the permission is applied. This field is required.
+        /// </summary>
+        public string Principal { get; set; }
+
+        /// <summary>
+        /// The permission level applied to the principal. This field is required.
+        /// </summary>
+        public PermissionLevel Permission { get; set; }
+
+        internal abstract Dictionary<string,string> ToDictionaryRepresentation();
+    }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/AclPermissionItem.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/AclPermissionItem.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.Databricks.Client
 {
@@ -20,5 +23,43 @@ namespace Microsoft.Azure.Databricks.Client
         [JsonConverter(typeof(StringEnumConverter))]
         [JsonProperty("permission_level")]
         public virtual PermissionLevel Permission { get; set; }
+
+        internal static IEnumerable<AclPermissionItem> ParseFromPermissionsHttpResult(JObject result)
+        {
+            if (!result.ContainsKey("access_control_list"))
+            {
+                return Enumerable.Empty<AclPermissionItem>();
+            }
+            List<AclPermissionItem> list = new List<AclPermissionItem>();
+            var acl = result["access_control_list"].Children<JObject>();
+            var groups = 
+                from rules in acl
+                where rules.ContainsKey("group_name")
+                select new GroupAclItem
+                {
+                    Principal = (string)rules["group_name"],
+                    Permission = (PermissionLevel)Enum.Parse(typeof(PermissionLevel), (string)rules["all_permissions"]["permission_level"])
+                };
+            var users = 
+                from rules in acl
+                where rules.ContainsKey("user_name")
+                select new UserAclItem
+                {
+                    Principal = (string)rules["user_name"],
+                    Permission = (PermissionLevel)Enum.Parse(typeof(PermissionLevel), (string)rules["all_permissions"]["permission_level"])
+                };
+            var servicePrincipals = 
+                from rules in acl
+                where rules.ContainsKey("service_principal_name")
+                select new ServicePrincipalAclItem
+                {
+                    Principal = (string)rules["service_principal_name"],
+                    Permission = (PermissionLevel)Enum.Parse(typeof(PermissionLevel), (string)rules["all_permissions"]["permission_level"])
+                };
+            list.AddRange(groups);
+            list.AddRange(users);
+            list.AddRange(servicePrincipals);
+            return list;
+        }
     }
 }

--- a/csharp/Microsoft.Azure.Databricks.Client/AclPermissionItem.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/AclPermissionItem.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Databricks.Client
                 select new GroupAclItem
                 {
                     Principal = (string)rules["group_name"],
-                    Permission = (PermissionLevel)Enum.Parse(typeof(PermissionLevel), (string)rules["all_permissions"]["permission_level"])
+                    Permission = (PermissionLevel)Enum.Parse(typeof(PermissionLevel), (string)rules["all_permissions"][0]["permission_level"])
                 };
             var users = 
                 from rules in acl
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Databricks.Client
                 select new UserAclItem
                 {
                     Principal = (string)rules["user_name"],
-                    Permission = (PermissionLevel)Enum.Parse(typeof(PermissionLevel), (string)rules["all_permissions"]["permission_level"])
+                    Permission = (PermissionLevel)Enum.Parse(typeof(PermissionLevel), (string)rules["all_permissions"][0]["permission_level"])
                 };
             var servicePrincipals = 
                 from rules in acl
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Databricks.Client
                 select new ServicePrincipalAclItem
                 {
                     Principal = (string)rules["service_principal_name"],
-                    Permission = (PermissionLevel)Enum.Parse(typeof(PermissionLevel), (string)rules["all_permissions"]["permission_level"])
+                    Permission = (PermissionLevel)Enum.Parse(typeof(PermissionLevel), (string)rules["all_permissions"][0]["permission_level"])
                 };
             list.AddRange(groups);
             list.AddRange(users);

--- a/csharp/Microsoft.Azure.Databricks.Client/ApiClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/ApiClient.cs
@@ -65,6 +65,38 @@ namespace Microsoft.Azure.Databricks.Client
             return JsonConvert.DeserializeObject<TResult>(responseContent);
         }
 
+        protected static async Task<TResult> HttpPatch<TBody, TResult>(HttpClient httpClient, string requestUri, TBody body, CancellationToken cancellationToken = default)
+        {
+            HttpContent content = new StringContent(JsonConvert.SerializeObject(body, JsonSerializerSettings));
+            HttpRequestMessage msg = new HttpRequestMessage(new HttpMethod("PATCH"), requestUri)
+            {
+                Content = content
+            };
+            var response = await httpClient.SendAsync(msg).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw CreateApiException(response);
+            }
+
+            var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<TResult>(responseContent);
+        }
+
+        protected static async Task<TResult> HttpPut<TBody, TResult>(HttpClient httpClient, string requestUri, TBody body, CancellationToken cancellationToken = default)
+        {
+            HttpContent content = new StringContent(JsonConvert.SerializeObject(body, JsonSerializerSettings));
+            var response = await httpClient.PutAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw CreateApiException(response);
+            }
+
+            var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<TResult>(responseContent);
+        }
+
         protected static bool PropertyExists(JObject obj, string propertyName)
         {
             return obj.ContainsKey(propertyName);

--- a/csharp/Microsoft.Azure.Databricks.Client/ApiClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/ApiClient.cs
@@ -65,6 +65,21 @@ namespace Microsoft.Azure.Databricks.Client
             return JsonConvert.DeserializeObject<TResult>(responseContent);
         }
 
+        protected static async Task HttpPatch<TBody>(HttpClient httpClient, string requestUri, TBody body, CancellationToken cancellationToken = default)
+        {
+            HttpContent content = new StringContent(JsonConvert.SerializeObject(body, JsonSerializerSettings));
+            HttpRequestMessage msg = new HttpRequestMessage(new HttpMethod("PATCH"), requestUri)
+            {
+                Content = content
+            };
+            var response = await httpClient.SendAsync(msg).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw CreateApiException(response);
+            }
+        }
+
         protected static async Task<TResult> HttpPatch<TBody, TResult>(HttpClient httpClient, string requestUri, TBody body, CancellationToken cancellationToken = default)
         {
             HttpContent content = new StringContent(JsonConvert.SerializeObject(body, JsonSerializerSettings));
@@ -95,6 +110,17 @@ namespace Microsoft.Azure.Databricks.Client
 
             var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             return JsonConvert.DeserializeObject<TResult>(responseContent);
+        }
+
+        protected static async Task HttpPut<TBody>(HttpClient httpClient, string requestUri, TBody body, CancellationToken cancellationToken = default)
+        {
+            HttpContent content = new StringContent(JsonConvert.SerializeObject(body, JsonSerializerSettings));
+            var response = await httpClient.PutAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw CreateApiException(response);
+            }
         }
 
         protected static bool PropertyExists(JObject obj, string propertyName)

--- a/csharp/Microsoft.Azure.Databricks.Client/DatabricksClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/DatabricksClient.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Azure.Databricks.Client
             this.Token = new TokenApiClient(httpClient);
             this.Workspace = new WorkspaceApiClient(httpClient);
             this.InstancePool = new InstancePoolApiClient(httpClient);
+            this.Permissions = new PermissionsApiClient(httpClient);
         }
 
         /// <summary>
@@ -170,6 +171,8 @@ namespace Microsoft.Azure.Databricks.Client
         public IWorkspaceApi Workspace { get; }
 
         public IInstancePoolApi InstancePool { get; }
+
+        public IPermissionsApi Permissions { get; }
 
         public void Dispose()
         {

--- a/csharp/Microsoft.Azure.Databricks.Client/GroupAclItem.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/GroupAclItem.cs
@@ -1,0 +1,20 @@
+
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.Databricks.Client
+{
+    /// <summary>
+    /// An item representing an ACL rule applied to a specific group. To be used when updated permission levels through the permissions Api
+    /// </summary>
+    public class GroupAclItem : AclPermissionItem
+    {
+        internal override Dictionary<string, string> ToDictionaryRepresentation()
+        {
+            return new Dictionary<string, string>
+            {
+                {"group_name", Principal},
+                {"permission_level", Permission.ToString()}
+            };
+        }
+    }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/GroupAclItem.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/GroupAclItem.cs
@@ -1,5 +1,6 @@
 
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Databricks.Client
 {
@@ -8,13 +9,7 @@ namespace Microsoft.Azure.Databricks.Client
     /// </summary>
     public class GroupAclItem : AclPermissionItem
     {
-        internal override Dictionary<string, string> ToDictionaryRepresentation()
-        {
-            return new Dictionary<string, string>
-            {
-                {"group_name", Principal},
-                {"permission_level", Permission.ToString()}
-            };
-        }
+        [JsonProperty("group_name")]
+        public override string Principal { get => base.Principal; set => base.Principal = value; }
     }
 }

--- a/csharp/Microsoft.Azure.Databricks.Client/IPermissionsApi.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/IPermissionsApi.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Databricks.Client
                 /// based on the state of the workspace or the permissions of the calling user. This request is published
                 /// for consistency with other permissions APIs.
                 /// </summary>
-                Task<IEnumerable<(PermissionLevel, string description)>> GetTokenPermissionsLevels(CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionDescription>> GetTokenPermissionsLevels(CancellationToken cancellationToken = default);
 
                 /// <summary>
                 /// Get the set of all token permissions for the workspace. 
@@ -49,52 +49,52 @@ namespace Microsoft.Azure.Databricks.Client
                 /// <returns></returns>
                 Task ReplaceTokenPermissionsForWorkspace(IEnumerable<AclPermissionItem> AccessControlList, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetClusterPermissionLevels(string clusterId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionDescription>> GetClusterPermissionLevels(string clusterId, CancellationToken cancellationToken = default);
                 Task<IEnumerable<AclPermissionItem>> GetClusterPermissions(string clusterId, CancellationToken cancellationToken = default);
                 Task UpdateClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId, CancellationToken cancellationToken = default);
                 Task ReplaceClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetInstancePoolPermissionLevels(string instancePoolId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionDescription>> GetInstancePoolPermissionLevels(string instancePoolId, CancellationToken cancellationToken = default);
                 Task<IEnumerable<AclPermissionItem>> GetInstancePoolPermissions(string instancePoolId, CancellationToken cancellationToken = default);
                 Task UpdateInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId, CancellationToken cancellationToken = default);
                 Task ReplaceInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetJobPermissionLevels(string jobId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionDescription>> GetJobPermissionLevels(string jobId, CancellationToken cancellationToken = default);
                 Task<IEnumerable<AclPermissionItem>> GetJobPermissions(string jobId, CancellationToken cancellationToken = default);
                 Task UpdateJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId, CancellationToken cancellationToken = default);
                 Task ReplaceJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetPipelinePermissionLevels(string pipelineId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionDescription>> GetPipelinePermissionLevels(string pipelineId, CancellationToken cancellationToken = default);
                 Task<IEnumerable<AclPermissionItem>> GetPipelinePermissions(string pipelineId, CancellationToken cancellationToken = default);
                 Task UpdatePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId, CancellationToken cancellationToken = default);
                 Task ReplacePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetNotebookPermissionLevels(string notebookId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionDescription>> GetNotebookPermissionLevels(string notebookId, CancellationToken cancellationToken = default);
                 Task<IEnumerable<AclPermissionItem>> GetNotebookPermissions(string notebookId, CancellationToken cancellationToken = default);
                 Task UpdateNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId, CancellationToken cancellationToken = default);
                 Task ReplaceNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetDirectoryPermissionLevels(string directoryId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionDescription>> GetDirectoryPermissionLevels(string directoryId, CancellationToken cancellationToken = default);
                 Task<IEnumerable<AclPermissionItem>> GetDirectoryPermissions(string directoryId, CancellationToken cancellationToken = default);
                 Task UpdateDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId, CancellationToken cancellationToken = default);
                 Task ReplaceDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetExperimentPermissionLevels(string experimentId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionDescription>> GetExperimentPermissionLevels(string experimentId, CancellationToken cancellationToken = default);
                 Task<IEnumerable<AclPermissionItem>> GetExperimentPermissions(string experimentId, CancellationToken cancellationToken = default);
                 Task UpdateExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId, CancellationToken cancellationToken = default);
                 Task ReplaceExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetRegisteredModelPermissionLevels(string registeredModelId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionDescription>> GetRegisteredModelPermissionLevels(string registeredModelId, CancellationToken cancellationToken = default);
                 Task<IEnumerable<AclPermissionItem>> GetRegisteredModelPermissions(string registeredModelId, CancellationToken cancellationToken = default);
                 Task UpdateRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId, CancellationToken cancellationToken = default);
                 Task ReplaceRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetSqlWarehousePermissionLevels(string endpointId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionDescription>> GetSqlWarehousePermissionLevels(string endpointId, CancellationToken cancellationToken = default);
                 Task<IEnumerable<AclPermissionItem>> GetSqlWarehousePermissions(string endpointId, CancellationToken cancellationToken = default);
                 Task UpdateSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId, CancellationToken cancellationToken = default);
                 Task ReplaceSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetRepoPermissionLevels(string repoId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionDescription>> GetRepoPermissionLevels(string repoId, CancellationToken cancellationToken = default);
                 Task<IEnumerable<AclPermissionItem>> GetRepoPermissions(string repoId, CancellationToken cancellationToken = default);
                 Task UpdateRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId, CancellationToken cancellationToken = default);
                 Task ReplaceRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId, CancellationToken cancellationToken = default);

--- a/csharp/Microsoft.Azure.Databricks.Client/IPermissionsApi.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/IPermissionsApi.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Databricks.Client
+{
+        public interface IPermissionsApi : IDisposable
+        {
+                /// <summary>
+                /// Returns a JSON representation of the possible permissions levels for tokens. For details, 
+                /// see the required token permission levels for various actions. The results of this request do not change 
+                /// based on the state of the workspace or the permissions of the calling user. This request is published
+                /// for consistency with other permissions APIs.
+                /// </summary>
+                Task<IEnumerable<(PermissionLevel, string description)>> GetTokenPermissionsLevels();
+
+                /// <summary>
+                /// Get the set of all token permissions for the workspace. 
+                /// </summary>
+                /// <returns></returns>
+                Task<IEnumerable<AclItem>> GetTokenPermissions();
+
+                /// <summary>
+                /// Grant token permissions for one or more users, groups, or service principals. 
+                /// You can only grant the Can Use (CAN_USE) permission. 
+                /// The Can Manage (CAN_MANAGE) permission level cannot be granted with this API 
+                /// because it is tied automatically to membership in the admins group.
+                /// IMPORTANT: You cannot use this request to revoke (remove) any permissions. 
+                /// The only way to remove permissions is with the replace token permissions for 
+                /// entire workspace API, which requires you specify the complete set of permissions 
+                /// for all objects that are granted permissions. 
+                /// </summary>
+                /// <param name="AccessControlList"></param>
+                /// <returns></returns>
+                Task UpdateTokenPermissions(IEnumerable<AclPermissionItem> AccessControlList);
+
+                /// <summary>
+                /// Update all token permissions for all users, groups, and service principals for 
+                /// the entire workspace. The permissions that you specify in this request overwrite 
+                /// the existing permissions entirely. You must provide a complete set of all 
+                /// permissions for all objects in one request.
+                /// At the end of processing your request, all users and service principals that 
+                /// do not have either CAN_USE or CAN_MANAGE permission either explicitly or implicitly 
+                /// due to group assignment no longer have any tokens permissions. Affected users or 
+                /// service principals immediately have all their tokens deleted.
+                /// </summary>
+                /// <param name="AccessControlList"></param>
+                /// <returns></returns>
+                Task ReplaceTokenPermissionsForWorkspace(IEnumerable<AclPermissionItem> AccessControlList);
+        }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/IPermissionsApi.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/IPermissionsApi.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Databricks.Client
         /// Asynchronously returns a list of <see cref="AclPermissionDescription"/> representing all possible
         /// <see cref="PermissionLevel"/> values that can be applied to tokens
         /// </summary>
-        Task<IEnumerable<AclPermissionDescription>> GetTokenPermissionsLevels(CancellationToken cancellationToken = default);
+        Task<IEnumerable<AclPermissionDescription>> GetTokenPermissionLevels(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Asynchronously returns a list of <see cref="AclPermissionItem"/> representing all current

--- a/csharp/Microsoft.Azure.Databricks.Client/IPermissionsApi.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/IPermissionsApi.cs
@@ -5,98 +5,365 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Databricks.Client
 {
-        public interface IPermissionsApi : IDisposable
-        {
-                /// <summary>
-                /// Asynchronously returns a list of <cref>AclPermissionDescription</cref> representing all possible
-                /// <cref>PermissionLevel</cref> values that can be applied to tokens
-                /// </summary>
-                /// <param name="cancellationToken"></param>
-                /// <returns></returns>
-                Task<IEnumerable<AclPermissionDescription>> GetTokenPermissionsLevels(CancellationToken cancellationToken = default);
+    public interface IPermissionsApi : IDisposable
+    {
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionDescription"/> representing all possible
+        /// <see cref="PermissionLevel"/> values that can be applied to tokens
+        /// </summary>
+        Task<IEnumerable<AclPermissionDescription>> GetTokenPermissionsLevels(CancellationToken cancellationToken = default);
 
-                /// <summary>
-                /// Get the set of all token permissions for the workspace. 
-                /// </summary>
-                /// <returns></returns>
-                Task<IEnumerable<AclPermissionItem>> GetTokenPermissions(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionItem"/> representing all current
+        /// permissions that are applied to tokens
+        /// </summary>
+        Task<IEnumerable<AclPermissionItem>> GetTokenPermissions(CancellationToken cancellationToken = default);
 
-                /// <summary>
-                /// Grant token permissions for one or more users, groups, or service principals. 
-                /// You can only grant the Can Use (CAN_USE) permission. 
-                /// The Can Manage (CAN_MANAGE) permission level cannot be granted with this API 
-                /// because it is tied automatically to membership in the admins group.
-                /// IMPORTANT: You cannot use this request to revoke (remove) any permissions. 
-                /// The only way to remove permissions is with the replace token permissions for 
-                /// entire workspace API, which requires you specify the complete set of permissions 
-                /// for all objects that are granted permissions. 
-                /// </summary>
-                /// <param name="AccessControlList"></param>
-                /// <returns></returns>
-                Task UpdateTokenPermissions(IEnumerable<AclPermissionItem> AccessControlList, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Grant token permissions for one or more users, groups, or service principals. 
+        /// You can only grant the Can Use (CAN_USE) permission. 
+        /// The Can Manage (CAN_MANAGE) permission level cannot be granted with this API 
+        /// because it is tied automatically to membership in the admins group.
+        /// IMPORTANT: You cannot use this request to revoke (remove) any permissions. 
+        /// The only way to remove permissions is with the replace token permissions for 
+        /// entire workspace API, which requires you specify the complete set of permissions 
+        /// for all objects that are granted permissions. 
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        Task UpdateTokenPermissions(IEnumerable<AclPermissionItem> AccessControlList, CancellationToken cancellationToken = default);
 
-                /// <summary>
-                /// Update all token permissions for all users, groups, and service principals for 
-                /// the entire workspace. The permissions that you specify in this request overwrite 
-                /// the existing permissions entirely. You must provide a complete set of all 
-                /// permissions for all objects in one request.
-                /// At the end of processing your request, all users and service principals that 
-                /// do not have either CAN_USE or CAN_MANAGE permission either explicitly or implicitly 
-                /// due to group assignment no longer have any tokens permissions. Affected users or 
-                /// service principals immediately have all their tokens deleted.
-                /// </summary>
-                /// <param name="AccessControlList"></param>
-                /// <returns></returns>
-                Task ReplaceTokenPermissionsForWorkspace(IEnumerable<AclPermissionItem> AccessControlList, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Update all token permissions for all users, groups, and service principals for 
+        /// the entire workspace. The permissions that you specify in this request overwrite 
+        /// the existing permissions entirely. You must provide a complete set of all 
+        /// permissions for all objects in one request.
+        /// At the end of processing your request, all users and service principals that 
+        /// do not have either CAN_USE or CAN_MANAGE permission either explicitly or implicitly 
+        /// due to group assignment no longer have any tokens permissions. Affected users or 
+        /// service principals immediately have all their tokens deleted.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        Task ReplaceTokenPermissionsForWorkspace(IEnumerable<AclPermissionItem> AccessControlList, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<AclPermissionDescription>> GetClusterPermissionLevels(string clusterId, CancellationToken cancellationToken = default);
-                Task<IEnumerable<AclPermissionItem>> GetClusterPermissions(string clusterId, CancellationToken cancellationToken = default);
-                Task UpdateClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId, CancellationToken cancellationToken = default);
-                Task ReplaceClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionDescription"/> representing all possible
+        /// <see cref="PermissionLevel"/> values that can be applied to the target cluster
+        /// </summary>
+        /// <param name="clusterId">The id of the target cluster</param>
+        Task<IEnumerable<AclPermissionDescription>> GetClusterPermissionLevels(string clusterId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<AclPermissionDescription>> GetInstancePoolPermissionLevels(string instancePoolId, CancellationToken cancellationToken = default);
-                Task<IEnumerable<AclPermissionItem>> GetInstancePoolPermissions(string instancePoolId, CancellationToken cancellationToken = default);
-                Task UpdateInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId, CancellationToken cancellationToken = default);
-                Task ReplaceInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionItem"/> representing all current
+        /// permissions that are applied to the target cluster
+        /// </summary>
+        /// <param name="clusterId">The id of the target cluster</param>
+        Task<IEnumerable<AclPermissionItem>> GetClusterPermissions(string clusterId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Grant cluster permissions for one or more users, groups, or service principals.
+        /// This request only grants (adds) permissions. To revoke, use <see cref="ReplaceClusterPermissions"/>.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="clusterId">The id of the target cluster</param>
+        Task UpdateClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Update all clusters permissions for a specific cluster, specifying all users, groups, or service principal.
+        /// WARNING: This request overwrites all existing direct (non-inherited) permissions on the cluster and replaces it with the new permissions specified in the request body.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="clusterId">The id of the target cluster</param>
+        Task ReplaceClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<AclPermissionDescription>> GetJobPermissionLevels(string jobId, CancellationToken cancellationToken = default);
-                Task<IEnumerable<AclPermissionItem>> GetJobPermissions(string jobId, CancellationToken cancellationToken = default);
-                Task UpdateJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId, CancellationToken cancellationToken = default);
-                Task ReplaceJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionDescription"/> representing all possible
+        /// <see cref="PermissionLevel"/> values that can be applied to the target instance pool
+        /// </summary>
+        /// <param name="instancePoolId">The id of the target instance pool</param>
+        Task<IEnumerable<AclPermissionDescription>> GetInstancePoolPermissionLevels(string instancePoolId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<AclPermissionDescription>> GetPipelinePermissionLevels(string pipelineId, CancellationToken cancellationToken = default);
-                Task<IEnumerable<AclPermissionItem>> GetPipelinePermissions(string pipelineId, CancellationToken cancellationToken = default);
-                Task UpdatePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId, CancellationToken cancellationToken = default);
-                Task ReplacePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionItem"/> representing all current
+        /// permissions that are applied to the target instance pool
+        /// </summary>
+        /// <param name="instancePoolId">The id of the target instance pool</param>
+        Task<IEnumerable<AclPermissionItem>> GetInstancePoolPermissions(string instancePoolId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Grant pool permissions for one or more users, groups, or service principal.
+        /// This request only grants (adds) permissions. To revoke, use <see cref="ReplaceInstancePoolPermissions"/>.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="instancePoolId">The id of the target instance pool</param>
+        Task UpdateInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Update all pool permissions for all users, groups, or service principal for a specific pool.
+        /// WARNING: This request overwrites all existing permissions on the pool and replaces it with the new permissions specified in the request body.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="instancePoolId">The id of the target instance pool</param>
+        Task ReplaceInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<AclPermissionDescription>> GetNotebookPermissionLevels(string notebookId, CancellationToken cancellationToken = default);
-                Task<IEnumerable<AclPermissionItem>> GetNotebookPermissions(string notebookId, CancellationToken cancellationToken = default);
-                Task UpdateNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId, CancellationToken cancellationToken = default);
-                Task ReplaceNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionDescription"/> representing all possible
+        /// <see cref="PermissionLevel"/> values that can be applied to the target job
+        /// </summary>
+        /// <param name="jobId">The id of the target job</param>
+        Task<IEnumerable<AclPermissionDescription>> GetJobPermissionLevels(string jobId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<AclPermissionDescription>> GetDirectoryPermissionLevels(string directoryId, CancellationToken cancellationToken = default);
-                Task<IEnumerable<AclPermissionItem>> GetDirectoryPermissions(string directoryId, CancellationToken cancellationToken = default);
-                Task UpdateDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId, CancellationToken cancellationToken = default);
-                Task ReplaceDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionItem"/> representing all current
+        /// permissions that are applied to the target job
+        /// </summary>
+        /// <param name="jobId">The id of the target job</param>
+        Task<IEnumerable<AclPermissionItem>> GetJobPermissions(string jobId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Grant jobs permissions for one or more users, groups, or service principals.
+        /// This request only grants (adds) permissions. To revoke, use <see cref="ReplaceJobPermissions"/>.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="jobId">The id of the target job</param>
+        Task UpdateJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Update all jobs permissions for all users, groups, or service principal for a specific job.
+        /// WARNING: This request overwrites all existing direct permissions on the job and replaces it with the new permissions specified in the request body.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="jobId">The id of the target job</param>
+        Task ReplaceJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<AclPermissionDescription>> GetExperimentPermissionLevels(string experimentId, CancellationToken cancellationToken = default);
-                Task<IEnumerable<AclPermissionItem>> GetExperimentPermissions(string experimentId, CancellationToken cancellationToken = default);
-                Task UpdateExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId, CancellationToken cancellationToken = default);
-                Task ReplaceExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionDescription"/> representing all possible
+        /// <see cref="PermissionLevel"/> values that can be applied to the target pipeline
+        /// </summary>
+        /// <param name="pipelineId">The id of the target pipeline</param>
+        Task<IEnumerable<AclPermissionDescription>> GetPipelinePermissionLevels(string pipelineId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<AclPermissionDescription>> GetRegisteredModelPermissionLevels(string registeredModelId, CancellationToken cancellationToken = default);
-                Task<IEnumerable<AclPermissionItem>> GetRegisteredModelPermissions(string registeredModelId, CancellationToken cancellationToken = default);
-                Task UpdateRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId, CancellationToken cancellationToken = default);
-                Task ReplaceRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionItem"/> representing all current
+        /// permissions that are applied to the target pipeline
+        /// </summary>
+        /// <param name="pipelineId">The id of the target pipeline</param>
+        Task<IEnumerable<AclPermissionItem>> GetPipelinePermissions(string pipelineId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Grant permissions on a pipeline for one or more users, groups, or service principals.
+        /// This request only grants (adds) permissions. To revoke, use <see cref="ReplacePipelinePermissions"/>.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="pipelineId">The id of the target pipeline</param>
+        Task UpdatePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Update permissions granted to users, groups and service principals on the specified pipeline.
+        /// WARNING: This request overwrites all existing direct (non-inherited) permissions on the pipeline and replaces it with the new permissions specified in the request body.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="pipelineId">The id of the target pipeline</param>
+        Task ReplacePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<AclPermissionDescription>> GetSqlWarehousePermissionLevels(string endpointId, CancellationToken cancellationToken = default);
-                Task<IEnumerable<AclPermissionItem>> GetSqlWarehousePermissions(string endpointId, CancellationToken cancellationToken = default);
-                Task UpdateSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId, CancellationToken cancellationToken = default);
-                Task ReplaceSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionDescription"/> representing all possible
+        /// <see cref="PermissionLevel"/> values that can be applied to the target notebook
+        /// </summary>
+        /// <param name="notebookId">The id of the target notebook</param>
+        Task<IEnumerable<AclPermissionDescription>> GetNotebookPermissionLevels(string notebookId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<AclPermissionDescription>> GetRepoPermissionLevels(string repoId, CancellationToken cancellationToken = default);
-                Task<IEnumerable<AclPermissionItem>> GetRepoPermissions(string repoId, CancellationToken cancellationToken = default);
-                Task UpdateRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId, CancellationToken cancellationToken = default);
-                Task ReplaceRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId, CancellationToken cancellationToken = default);
-        }
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionItem"/> representing all current
+        /// permissions that are applied to the target notebook
+        /// </summary>
+        /// <param name="notebookId">The id of the target notebook</param>
+        Task<IEnumerable<AclPermissionItem>> GetNotebookPermissions(string notebookId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Grant a notebook new permissions for one or more users, groups, or service principals.
+        /// This request only grants (adds) permissions. To revoke, use <see cref="ReplaceNotebookPermissions"/>.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="notebookId">The id of the target notebook</param>
+        Task UpdateNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Update all notebooks permissions for all users, groups, or service principal for a specific notebook.
+        /// WARNING: This request overwrites all existing direct permissions on the notebook and replaces it with the new permissions specified in the request body.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="notebookId">The id of the target notebook</param>
+        Task ReplaceNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionDescription"/> representing all possible
+        /// <see cref="PermissionLevel"/> values that can be applied to the target directory
+        /// </summary>
+        /// <param name="directoryId">The id of the target directory</param>
+        Task<IEnumerable<AclPermissionDescription>> GetDirectoryPermissionLevels(string directoryId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionItem"/> representing all current
+        /// permissions that are applied to the target directory
+        /// </summary>
+        /// <param name="directoryId">The id of the target directory</param>
+        Task<IEnumerable<AclPermissionItem>> GetDirectoryPermissions(string directoryId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Grant a directory new permissions for one or more users, groups, or service principals.
+        /// This request only grants (adds) permissions. To revoke, use <see cref="ReplaceDirectoryPermissions"/>.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="directoryId">The id of the target directory</param>
+        Task UpdateDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Update all directory permissions for all users, groups, or service principal for a specific directory.
+        /// WARNING: This request overwrites all existing direct permissions on the directory and replaces it with the new permissions specified in the request body.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="directoryId">The id of the target directory</param>
+        Task ReplaceDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionDescription"/> representing all possible
+        /// <see cref="PermissionLevel"/> values that can be applied to the target ML Flow experiment
+        /// </summary>
+        /// <param name="experimentId">The id of the target ML Flow experiment</param>
+        Task<IEnumerable<AclPermissionDescription>> GetExperimentPermissionLevels(string experimentId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionItem"/> representing all current
+        /// permissions that are applied to the target ML Flow experiment
+        /// </summary>
+        /// <param name="experimentId">The id of the target ML Flow experiment</param>
+        Task<IEnumerable<AclPermissionItem>> GetExperimentPermissions(string experimentId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Grant an experiment new permissions for one or more users, groups, or service principals.
+        /// This request only grants (adds) permissions. To revoke, use <see cref="ReplaceExperimentPermissions"/>.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="experimentId">The id of the target ML Flow experiment</param>
+        Task UpdateExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Update all experiment permissions for all users, groups or service principal for a specific experiment.
+        /// WARNING: This request overwrites all existing direct permissions on the experiment and replaces it with the new permissions specified in the request body.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="experimentId">The id of the target ML Flow experiment</param>
+        Task ReplaceExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionDescription"/> representing all possible
+        /// <see cref="PermissionLevel"/> values that can be applied to the target ML Flow registered model
+        /// </summary>
+        /// <param name="registeredModelId">The id of the target ML Flow registered model</param>
+        Task<IEnumerable<AclPermissionDescription>> GetRegisteredModelPermissionLevels(string registeredModelId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionItem"/> representing all current
+        /// permissions that are applied to the target ML Flow registered model
+        /// </summary>
+        /// <param name="registeredModelId">The id of the target ML Flow registered model</param>
+        Task<IEnumerable<AclPermissionItem>> GetRegisteredModelPermissions(string registeredModelId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Grant MLflow registered model permissions for one or more users, groups, or service principals.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="registeredModelId">The id of the target Ml Flow registered model</param>
+        Task UpdateRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Update all MLflow registered model permissions for all users, groups, or service principal for a specific registered model.
+        /// WARNING: This request overwrites all existing direct permissions on the registered model and replaces it with the new permissions specified in the request body.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="registeredModelId">The id of the target Ml Flow registered model</param>
+        Task ReplaceRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionDescription"/> representing all possible
+        /// <see cref="PermissionLevel"/> values that can be applied to the target Sql warehouse
+        /// </summary>
+        /// <param name="endpointId">The endpoint id of the target Sql warehouse</param>
+        Task<IEnumerable<AclPermissionDescription>> GetSqlWarehousePermissionLevels(string endpointId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionItem"/> representing all current
+        /// permissions that are applied to the target Sql warehous
+        /// </summary>
+        /// <param name="endpointId">The endpoint id of the target Sql warehouse</param>
+        Task<IEnumerable<AclPermissionItem>> GetSqlWarehousePermissions(string endpointId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Grant SQL warehouse permissions for one or more users, groups, or service principals.
+        /// This request only grants (adds) permissions. To revoke, use <see cref="ReplaceSqlWarehousePermissions"/>.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="endpointId">The id of the target Sql warehous</param>
+        Task UpdateSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Update all permissions for a specific SQL warehouse, specifying all users, groups or service principal.
+        /// WARNING: This request overwrites all existing direct (non-inherited) permissions on the SQL warehouse and replaces it with the new permissions specified in the request body.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="endpointId">The id of the target Sql warehous</param>
+        Task ReplaceSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionDescription"/> representing all possible
+        /// <see cref="PermissionLevel"/> values that can be applied to the target repository
+        /// </summary>
+        /// <param name="repoId">The id of the target repository</param>
+        Task<IEnumerable<AclPermissionDescription>> GetRepoPermissionLevels(string repoId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously returns a list of <see cref="AclPermissionItem"/> representing all current
+        /// permissions that are applied to the target repository
+        /// </summary>
+        /// <param name="repoId">The id of the target repository</param>
+        Task<IEnumerable<AclPermissionItem>> GetRepoPermissions(string repoId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Grant a repo new permissions for one or more users, groups, or service principals.
+        /// This request only grants (adds) permissions. To revoke, use <see cref="ReplaceRepoPermissions"/>.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="repoId">The id of the target repository</param>
+        Task UpdateRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Update all repos permissions for all users, groups or service principal for a specific repo.
+        /// WARNING: This request overwrites all existing direct permissions on the repo and replaces it with the new permissions specified in the request body.
+        /// </summary>
+        /// <param name="AccessControlList">A collection of <see cref="AclPermissionItem"/>
+        /// representing the permissions to be updated</param>
+        /// <param name="repoId">The id of the target repository</param>
+        Task ReplaceRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId, CancellationToken cancellationToken = default);
+    }
 }

--- a/csharp/Microsoft.Azure.Databricks.Client/IPermissionsApi.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/IPermissionsApi.cs
@@ -13,13 +13,13 @@ namespace Microsoft.Azure.Databricks.Client
                 /// based on the state of the workspace or the permissions of the calling user. This request is published
                 /// for consistency with other permissions APIs.
                 /// </summary>
-                Task<IEnumerable<(PermissionLevel, string description)>> GetTokenPermissionsLevels();
+                Task<IEnumerable<(PermissionLevel, string description)>> GetTokenPermissionsLevels(CancellationToken cancellationToken = default);
 
                 /// <summary>
                 /// Get the set of all token permissions for the workspace. 
                 /// </summary>
                 /// <returns></returns>
-                Task<IEnumerable<AclPermissionItem>> GetTokenPermissions();
+                Task<IEnumerable<AclPermissionItem>> GetTokenPermissions(CancellationToken cancellationToken = default);
 
                 /// <summary>
                 /// Grant token permissions for one or more users, groups, or service principals. 
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Databricks.Client
                 /// </summary>
                 /// <param name="AccessControlList"></param>
                 /// <returns></returns>
-                Task UpdateTokenPermissions(IEnumerable<AclPermissionItem> AccessControlList);
+                Task UpdateTokenPermissions(IEnumerable<AclPermissionItem> AccessControlList, CancellationToken cancellationToken = default);
 
                 /// <summary>
                 /// Update all token permissions for all users, groups, and service principals for 
@@ -47,56 +47,56 @@ namespace Microsoft.Azure.Databricks.Client
                 /// </summary>
                 /// <param name="AccessControlList"></param>
                 /// <returns></returns>
-                Task ReplaceTokenPermissionsForWorkspace(IEnumerable<AclPermissionItem> AccessControlList);
+                Task ReplaceTokenPermissionsForWorkspace(IEnumerable<AclPermissionItem> AccessControlList, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetClusterPermissionLevels(string clusterId);
-                Task<IEnumerable<AclPermissionItem>> GetClusterPermissions(string clusterId);
-                Task UpdateClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId);
-                Task ReplaceClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId);
+                Task<IEnumerable<(PermissionLevel, string description)>> GetClusterPermissionLevels(string clusterId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionItem>> GetClusterPermissions(string clusterId, CancellationToken cancellationToken = default);
+                Task UpdateClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId, CancellationToken cancellationToken = default);
+                Task ReplaceClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetInstancePoolPermissionLevels(string instancePoolId);
-                Task<IEnumerable<AclPermissionItem>> GetInstancePoolPermissions(string instancePoolId);
-                Task UpdateInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId);
-                Task ReplaceInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId);
+                Task<IEnumerable<(PermissionLevel, string description)>> GetInstancePoolPermissionLevels(string instancePoolId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionItem>> GetInstancePoolPermissions(string instancePoolId, CancellationToken cancellationToken = default);
+                Task UpdateInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId, CancellationToken cancellationToken = default);
+                Task ReplaceInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetJobPermissionLevels(string jobId);
-                Task<IEnumerable<AclPermissionItem>> GetJobPermissions(string jobId);
-                Task UpdateJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId);
-                Task ReplaceJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId);
+                Task<IEnumerable<(PermissionLevel, string description)>> GetJobPermissionLevels(string jobId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionItem>> GetJobPermissions(string jobId, CancellationToken cancellationToken = default);
+                Task UpdateJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId, CancellationToken cancellationToken = default);
+                Task ReplaceJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetPipelinePermissionLevels(string pipelineId);
-                Task<IEnumerable<AclPermissionItem>> GetPipelinePermissions(string pipelineId);
-                Task UpdatePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId);
-                Task ReplacePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId);
+                Task<IEnumerable<(PermissionLevel, string description)>> GetPipelinePermissionLevels(string pipelineId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionItem>> GetPipelinePermissions(string pipelineId, CancellationToken cancellationToken = default);
+                Task UpdatePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId, CancellationToken cancellationToken = default);
+                Task ReplacePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetNotebookPermissionLevels(string notebookId);
-                Task<IEnumerable<AclPermissionItem>> GetNotebookPermissions(string notebookId);
-                Task UpdateNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId);
-                Task ReplaceNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId);
+                Task<IEnumerable<(PermissionLevel, string description)>> GetNotebookPermissionLevels(string notebookId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionItem>> GetNotebookPermissions(string notebookId, CancellationToken cancellationToken = default);
+                Task UpdateNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId, CancellationToken cancellationToken = default);
+                Task ReplaceNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetDirectoryPermissionLevels(string directoryId);
-                Task<IEnumerable<AclPermissionItem>> GetDirectoryPermissions(string directoryId);
-                Task UpdateDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId);
-                Task ReplaceDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId);
+                Task<IEnumerable<(PermissionLevel, string description)>> GetDirectoryPermissionLevels(string directoryId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionItem>> GetDirectoryPermissions(string directoryId, CancellationToken cancellationToken = default);
+                Task UpdateDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId, CancellationToken cancellationToken = default);
+                Task ReplaceDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetExperimentPermissionLevels(string experimentId);
-                Task<IEnumerable<AclPermissionItem>> GetExperimentPermissions(string experimentId);
-                Task UpdateExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId);
-                Task ReplaceExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId);
+                Task<IEnumerable<(PermissionLevel, string description)>> GetExperimentPermissionLevels(string experimentId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionItem>> GetExperimentPermissions(string experimentId, CancellationToken cancellationToken = default);
+                Task UpdateExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId, CancellationToken cancellationToken = default);
+                Task ReplaceExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetRegisteredModelPermissionLevels(string registeredModelId);
-                Task<IEnumerable<AclPermissionItem>> GetRegisteredModelPermissions(string registeredModelId);
-                Task UpdateRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId);
-                Task ReplaceRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId);
+                Task<IEnumerable<(PermissionLevel, string description)>> GetRegisteredModelPermissionLevels(string registeredModelId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionItem>> GetRegisteredModelPermissions(string registeredModelId, CancellationToken cancellationToken = default);
+                Task UpdateRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId, CancellationToken cancellationToken = default);
+                Task ReplaceRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetSqlWarehousePermissionLevels(string endpointId);
-                Task<IEnumerable<AclPermissionItem>> GetSqlWarehousePermissions(string endpointId);
-                Task UpdateSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId);
-                Task ReplaceSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId);
+                Task<IEnumerable<(PermissionLevel, string description)>> GetSqlWarehousePermissionLevels(string endpointId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionItem>> GetSqlWarehousePermissions(string endpointId, CancellationToken cancellationToken = default);
+                Task UpdateSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId, CancellationToken cancellationToken = default);
+                Task ReplaceSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId, CancellationToken cancellationToken = default);
 
-                Task<IEnumerable<(PermissionLevel, string description)>> GetRepoPermissionLevels(string repoId);
-                Task<IEnumerable<AclPermissionItem>> GetRepoPermissions(string repoId);
-                Task UpdateRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId);
-                Task ReplaceRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId);
+                Task<IEnumerable<(PermissionLevel, string description)>> GetRepoPermissionLevels(string repoId, CancellationToken cancellationToken = default);
+                Task<IEnumerable<AclPermissionItem>> GetRepoPermissions(string repoId, CancellationToken cancellationToken = default);
+                Task UpdateRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId, CancellationToken cancellationToken = default);
+                Task ReplaceRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId, CancellationToken cancellationToken = default);
         }
 }

--- a/csharp/Microsoft.Azure.Databricks.Client/IPermissionsApi.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/IPermissionsApi.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Databricks.Client
                 /// Get the set of all token permissions for the workspace. 
                 /// </summary>
                 /// <returns></returns>
-                Task<IEnumerable<AclItem>> GetTokenPermissions();
+                Task<IEnumerable<AclPermissionItem>> GetTokenPermissions();
 
                 /// <summary>
                 /// Grant token permissions for one or more users, groups, or service principals. 
@@ -48,5 +48,55 @@ namespace Microsoft.Azure.Databricks.Client
                 /// <param name="AccessControlList"></param>
                 /// <returns></returns>
                 Task ReplaceTokenPermissionsForWorkspace(IEnumerable<AclPermissionItem> AccessControlList);
+
+                Task<IEnumerable<(PermissionLevel, string description)>> GetClusterPermissionLevels(string clusterId);
+                Task<IEnumerable<AclPermissionItem>> GetClusterPermissions(string clusterId);
+                Task UpdateClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId);
+                Task ReplaceClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId);
+
+                Task<IEnumerable<(PermissionLevel, string description)>> GetInstancePoolPermissionLevels(string instancePoolId);
+                Task<IEnumerable<AclPermissionItem>> GetInstancePoolPermissions(string instancePoolId);
+                Task UpdateInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId);
+                Task ReplaceInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId);
+
+                Task<IEnumerable<(PermissionLevel, string description)>> GetJobPermissionLevels(string jobId);
+                Task<IEnumerable<AclPermissionItem>> GetJobPermissions(string jobId);
+                Task UpdateJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId);
+                Task ReplaceJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId);
+
+                Task<IEnumerable<(PermissionLevel, string description)>> GetPipelinePermissionLevels(string pipelineId);
+                Task<IEnumerable<AclPermissionItem>> GetPipelinePermissions(string pipelineId);
+                Task UpdatePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId);
+                Task ReplacePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId);
+
+                Task<IEnumerable<(PermissionLevel, string description)>> GetNotebookPermissionLevels(string notebookId);
+                Task<IEnumerable<AclPermissionItem>> GetNotebookPermissions(string notebookId);
+                Task UpdateNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId);
+                Task ReplaceNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId);
+
+                Task<IEnumerable<(PermissionLevel, string description)>> GetDirectoryPermissionLevels(string directoryId);
+                Task<IEnumerable<AclPermissionItem>> GetDirectoryPermissions(string directoryId);
+                Task UpdateDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId);
+                Task ReplaceDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId);
+
+                Task<IEnumerable<(PermissionLevel, string description)>> GetExperimentPermissionLevels(string experimentId);
+                Task<IEnumerable<AclPermissionItem>> GetExperimentPermissions(string experimentId);
+                Task UpdateExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId);
+                Task ReplaceExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId);
+
+                Task<IEnumerable<(PermissionLevel, string description)>> GetRegisteredModelPermissionLevels(string registeredModelId);
+                Task<IEnumerable<AclPermissionItem>> GetRegisteredModelPermissions(string registeredModelId);
+                Task UpdateRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId);
+                Task ReplaceRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId);
+
+                Task<IEnumerable<(PermissionLevel, string description)>> GetSqlWarehousePermissionLevels(string endpointId);
+                Task<IEnumerable<AclPermissionItem>> GetSqlWarehousePermissions(string endpointId);
+                Task UpdateSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId);
+                Task ReplaceSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId);
+
+                Task<IEnumerable<(PermissionLevel, string description)>> GetRepoPermissionLevels(string repoId);
+                Task<IEnumerable<AclPermissionItem>> GetRepoPermissions(string repoId);
+                Task UpdateRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId);
+                Task ReplaceRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId);
         }
 }

--- a/csharp/Microsoft.Azure.Databricks.Client/IPermissionsApi.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/IPermissionsApi.cs
@@ -8,11 +8,11 @@ namespace Microsoft.Azure.Databricks.Client
         public interface IPermissionsApi : IDisposable
         {
                 /// <summary>
-                /// Returns a JSON representation of the possible permissions levels for tokens. For details, 
-                /// see the required token permission levels for various actions. The results of this request do not change 
-                /// based on the state of the workspace or the permissions of the calling user. This request is published
-                /// for consistency with other permissions APIs.
+                /// Asynchronously returns a list of <cref>AclPermissionDescription</cref> representing all possible
+                /// <cref>PermissionLevel</cref> values that can be applied to tokens
                 /// </summary>
+                /// <param name="cancellationToken"></param>
+                /// <returns></returns>
                 Task<IEnumerable<AclPermissionDescription>> GetTokenPermissionsLevels(CancellationToken cancellationToken = default);
 
                 /// <summary>

--- a/csharp/Microsoft.Azure.Databricks.Client/PermissionLevel.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/PermissionLevel.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Databricks.Client
         CAN_READ,
         CAN_EDIT,
         CAN_MANAGE_STAGING_VERSIONS,
-        CAN_MANAGE_PRODUCTION_VERSIONS
+        CAN_MANAGE_PRODUCTION_VERSIONS,
+        CAN_VIEW
     }
 }

--- a/csharp/Microsoft.Azure.Databricks.Client/PermissionLevel.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/PermissionLevel.cs
@@ -1,0 +1,10 @@
+namespace Microsoft.Azure.Databricks.Client
+{
+    /// <summary>
+    /// The ACL permission levels for use with the permissions api
+    /// </summary>
+    public enum PermissionLevel
+    {
+
+    }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/PermissionLevel.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/PermissionLevel.cs
@@ -1,10 +1,21 @@
 namespace Microsoft.Azure.Databricks.Client
 {
     /// <summary>
-    /// The ACL permission levels for use with the permissions api
+    /// The ACL permission levels for use with the permissions api. The 'GetPermissionLevels' methods
+    /// can be used to determine which levels are appropriate to which method. 
     /// </summary>
     public enum PermissionLevel
     {
-
+        CAN_USE,
+        CAN_MANAGE,
+        CAN_ATTACH_TO,
+        CAN_RESTART,
+        CAN_MANAGE_RUN,
+        IS_OWNER,
+        CAN_RUN,
+        CAN_READ,
+        CAN_EDIT,
+        CAN_MANAGE_STAGING_VERSIONS,
+        CAN_MANAGE_PRODUCTION_VERSIONS
     }
 }

--- a/csharp/Microsoft.Azure.Databricks.Client/PermissionsApiClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/PermissionsApiClient.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.Databricks.Client
             return AclPermissionItem.ParseFromPermissionsHttpResult(result);
         }
 
-        public async Task<IEnumerable<AclPermissionDescription>> GetTokenPermissionsLevels(CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<AclPermissionDescription>> GetTokenPermissionLevels(CancellationToken cancellationToken = default)
         {
             const string requestUri = "permissions/authorization/tokens/permissionLevels";
             var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);

--- a/csharp/Microsoft.Azure.Databricks.Client/PermissionsApiClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/PermissionsApiClient.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Azure.Databricks.Client
         public async Task<IEnumerable<AclPermissionItem>> GetClusterPermissions(string clusterId, CancellationToken cancellationToken = default)
         {
             var requestUri = $"permissions/clusters/{clusterId}";
-            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return AclPermissionItem.ParseFromPermissionsHttpResult(result);
         }
 
         public async Task<IEnumerable<AclPermissionDescription>> GetDirectoryPermissionLevels(string directoryId, CancellationToken cancellationToken = default)
@@ -39,7 +40,8 @@ namespace Microsoft.Azure.Databricks.Client
         public async Task<IEnumerable<AclPermissionItem>> GetDirectoryPermissions(string directoryId, CancellationToken cancellationToken = default)
         {
             var requestUri = $"permissions/directories/{directoryId}";
-            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return AclPermissionItem.ParseFromPermissionsHttpResult(result);
         }
 
         public async Task<IEnumerable<AclPermissionDescription>> GetExperimentPermissionLevels(string experimentId, CancellationToken cancellationToken = default)
@@ -54,7 +56,8 @@ namespace Microsoft.Azure.Databricks.Client
         public async Task<IEnumerable<AclPermissionItem>> GetExperimentPermissions(string experimentId, CancellationToken cancellationToken = default)
         {
             var requestUri = $"permissions/experiments/{experimentId}";
-            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return AclPermissionItem.ParseFromPermissionsHttpResult(result);
         }
 
         public async Task<IEnumerable<AclPermissionDescription>> GetInstancePoolPermissionLevels(string instancePoolId, CancellationToken cancellationToken = default)
@@ -69,7 +72,8 @@ namespace Microsoft.Azure.Databricks.Client
         public async Task<IEnumerable<AclPermissionItem>> GetInstancePoolPermissions(string instancePoolId, CancellationToken cancellationToken = default)
         {
             var requestUri = $"permissions/instance-pools/{instancePoolId}";
-            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return AclPermissionItem.ParseFromPermissionsHttpResult(result);
         }
 
         public async Task<IEnumerable<AclPermissionDescription>> GetJobPermissionLevels(string jobId, CancellationToken cancellationToken = default)
@@ -84,7 +88,8 @@ namespace Microsoft.Azure.Databricks.Client
         public async Task<IEnumerable<AclPermissionItem>> GetJobPermissions(string jobId, CancellationToken cancellationToken = default)
         {
             var requestUri = $"permissions/jobs/{jobId}";
-            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return AclPermissionItem.ParseFromPermissionsHttpResult(result);
         }
 
         public async Task<IEnumerable<AclPermissionDescription>> GetNotebookPermissionLevels(string notebookId, CancellationToken cancellationToken = default)
@@ -99,7 +104,8 @@ namespace Microsoft.Azure.Databricks.Client
         public async Task<IEnumerable<AclPermissionItem>> GetNotebookPermissions(string notebookId, CancellationToken cancellationToken = default)
         {
             var requestUri = $"permissions/notebooks/{notebookId}";
-            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return AclPermissionItem.ParseFromPermissionsHttpResult(result);
         }
 
         public async Task<IEnumerable<AclPermissionDescription>> GetPipelinePermissionLevels(string pipelineId, CancellationToken cancellationToken = default)
@@ -114,7 +120,8 @@ namespace Microsoft.Azure.Databricks.Client
         public async Task<IEnumerable<AclPermissionItem>> GetPipelinePermissions(string pipelineId, CancellationToken cancellationToken = default)
         {
             var requestUri = $"permissions/pipelines/{pipelineId}";
-            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return AclPermissionItem.ParseFromPermissionsHttpResult(result);
         }
 
         public async Task<IEnumerable<AclPermissionDescription>> GetRegisteredModelPermissionLevels(string registeredModelId, CancellationToken cancellationToken = default)
@@ -129,7 +136,8 @@ namespace Microsoft.Azure.Databricks.Client
         public async Task<IEnumerable<AclPermissionItem>> GetRegisteredModelPermissions(string registeredModelId, CancellationToken cancellationToken = default)
         {
             var requestUri = $"permissions/registered-models/{registeredModelId}";
-            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return AclPermissionItem.ParseFromPermissionsHttpResult(result);
         }
 
         public async Task<IEnumerable<AclPermissionDescription>> GetRepoPermissionLevels(string repoId, CancellationToken cancellationToken = default)
@@ -144,7 +152,8 @@ namespace Microsoft.Azure.Databricks.Client
         public async Task<IEnumerable<AclPermissionItem>> GetRepoPermissions(string repoId, CancellationToken cancellationToken = default)
         {
             var requestUri = $"permissions/repos/{repoId}";
-            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return AclPermissionItem.ParseFromPermissionsHttpResult(result);
         }
 
         public async Task<IEnumerable<AclPermissionDescription>> GetSqlWarehousePermissionLevels(string endpointId, CancellationToken cancellationToken = default)
@@ -159,13 +168,15 @@ namespace Microsoft.Azure.Databricks.Client
         public async Task<IEnumerable<AclPermissionItem>> GetSqlWarehousePermissions(string endpointId, CancellationToken cancellationToken = default)
         {
             var requestUri = $"permissions/sql/endpoints/{endpointId}";
-            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return AclPermissionItem.ParseFromPermissionsHttpResult(result);
         }
 
         public async Task<IEnumerable<AclPermissionItem>> GetTokenPermissions(CancellationToken cancellationToken = default)
         {
             const string requestUri = "permissions/authorization/tokens";
-            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return AclPermissionItem.ParseFromPermissionsHttpResult(result);
         }
 
         public async Task<IEnumerable<AclPermissionDescription>> GetTokenPermissionsLevels(CancellationToken cancellationToken = default)

--- a/csharp/Microsoft.Azure.Databricks.Client/PermissionsApiClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/PermissionsApiClient.cs
@@ -1,4 +1,3 @@
-
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;

--- a/csharp/Microsoft.Azure.Databricks.Client/PermissionsApiClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/PermissionsApiClient.cs
@@ -1,0 +1,301 @@
+
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Databricks.Client
+{
+        public class PermissionsApiClient : ApiClient, IPermissionsApi
+        {
+                public PermissionsApiClient(HttpClient httpClient) : base(httpClient)
+                {
+                }
+
+                public async Task<IEnumerable<(PermissionLevel, string description)>> GetClusterPermissionLevels(string clusterId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/clusters/{clusterId}/permissionLevels";
+                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<AclPermissionItem>> GetClusterPermissions(string clusterId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/clusters/{clusterId}";
+                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<(PermissionLevel, string description)>> GetDirectoryPermissionLevels(string directoryId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/directories/{directoryId}/permissionLevels";
+                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<AclPermissionItem>> GetDirectoryPermissions(string directoryId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/directories/{directoryId}";
+                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<(PermissionLevel, string description)>> GetExperimentPermissionLevels(string experimentId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/experiments/{experimentId}/permissionLevels";
+                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<AclPermissionItem>> GetExperimentPermissions(string experimentId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/experiments/{experimentId}";
+                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<(PermissionLevel, string description)>> GetInstancePoolPermissionLevels(string instancePoolId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/instance-pools/{instancePoolId}/permissionLevels";
+                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<AclPermissionItem>> GetInstancePoolPermissions(string instancePoolId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/instance-pools/{instancePoolId}";
+                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<(PermissionLevel, string description)>> GetJobPermissionLevels(string jobId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/jobs/{jobId}/permissionLevels";
+                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<AclPermissionItem>> GetJobPermissions(string jobId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/jobs/{jobId}";
+                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<(PermissionLevel, string description)>> GetNotebookPermissionLevels(string notebookId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/notebooks/{notebookId}/permissionLevels";
+                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<AclPermissionItem>> GetNotebookPermissions(string notebookId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/notebooks/{notebookId}";
+                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<(PermissionLevel, string description)>> GetPipelinePermissionLevels(string pipelineId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/pipelines/{pipelineId}/permissionLevels";
+                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<AclPermissionItem>> GetPipelinePermissions(string pipelineId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/pipelines/{pipelineId}";
+                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<(PermissionLevel, string description)>> GetRegisteredModelPermissionLevels(string registeredModelId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/registered-models/{registeredModelId}/permissionLevels";
+                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<AclPermissionItem>> GetRegisteredModelPermissions(string registeredModelId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/registered-models/{registeredModelId}";
+                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<(PermissionLevel, string description)>> GetRepoPermissionLevels(string repoId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/repos/{repoId}/permissionLevels";
+                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<AclPermissionItem>> GetRepoPermissions(string repoId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/repos/{repoId}";
+                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<(PermissionLevel, string description)>> GetSqlWarehousePermissionLevels(string endpointId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/sql/endpoints/{endpointId}/permissionLevels";
+                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<AclPermissionItem>> GetSqlWarehousePermissions(string endpointId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/sql/endpoints/{endpointId}";
+                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<AclPermissionItem>> GetTokenPermissions(CancellationToken cancellationToken = default)
+                {
+                        const string requestUri = "permissions/authorization/tokens";
+                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task<IEnumerable<(PermissionLevel, string description)>> GetTokenPermissionsLevels(CancellationToken cancellationToken = default)
+                {
+                        const string requestUri = "permissions/authorization/tokens/permissionLevels";
+                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
+                }
+
+                public async Task ReplaceClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/clusters/{clusterId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
+                }
+
+                public async Task ReplaceDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/directories/{directoryId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
+                }
+
+                public async Task ReplaceExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/experiments/{experimentId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
+                }
+
+                public async Task ReplaceInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/instance-pools/{instancePoolId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
+                }
+
+                public async Task ReplaceJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/jobs/{jobId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
+                }
+
+                public async Task ReplaceNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/notebooks/{notebookId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
+                }
+
+                public async Task ReplacePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/pipelines/{pipelineId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
+                }
+
+                public async Task ReplaceRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/registered-models/{registeredModelId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
+                }
+
+                public async Task ReplaceRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/repos/{repoId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
+                }
+
+                public async Task ReplaceSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/sql/endpoints/{endpointId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
+                }
+
+                public async Task ReplaceTokenPermissionsForWorkspace(IEnumerable<AclPermissionItem> AccessControlList, CancellationToken cancellationToken = default)
+                {
+                        const string requestUri = "permissions/authorization/tokens";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
+                }
+
+                public async Task UpdateClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/clusters/{clusterId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPatch(HttpClient, requestUri, body);
+                }
+
+                public async Task UpdateDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/directories/{directoryId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPatch(HttpClient, requestUri, body);
+                }
+
+                public async Task UpdateExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/experiments/{experimentId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPatch(HttpClient, requestUri, body);
+                }
+
+                public async Task UpdateInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/instance-pools/{instancePoolId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPatch(HttpClient, requestUri, body);
+                }
+
+                public async Task UpdateJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/jobs/{jobId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPatch(HttpClient, requestUri, body);
+                }
+
+                public async Task UpdateNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/notebooks/{notebookId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPatch(HttpClient, requestUri, body);
+                }
+
+                public async Task UpdatePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/pipelines/{pipelineId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPatch(HttpClient, requestUri, body);
+                }
+
+                public async Task UpdateRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/registered-models/{registeredModelId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPatch(HttpClient, requestUri, body);
+                }
+
+                public async Task UpdateRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/repos/{repoId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPatch(HttpClient, requestUri, body);
+                }
+
+                public async Task UpdateSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId, CancellationToken cancellationToken = default)
+                {
+                        var requestUri = $"permissions/sql/endpoints/{endpointId}";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPatch(HttpClient, requestUri, body);
+                }
+
+                public async Task UpdateTokenPermissions(IEnumerable<AclPermissionItem> AccessControlList, CancellationToken cancellationToken = default)
+                {
+                        const string requestUri = "permissions/authorization/tokens";
+                        var body = new {access_control_list = AccessControlList};
+                        await HttpPatch(HttpClient, requestUri, body);
+                }
+        }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/PermissionsApiClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/PermissionsApiClient.cs
@@ -1,300 +1,334 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Databricks.Client
 {
-        public class PermissionsApiClient : ApiClient, IPermissionsApi
+    public class PermissionsApiClient : ApiClient, IPermissionsApi
+    {
+        public PermissionsApiClient(HttpClient httpClient) : base(httpClient)
         {
-                public PermissionsApiClient(HttpClient httpClient) : base(httpClient)
-                {
-                }
-
-                public async Task<IEnumerable<(PermissionLevel, string description)>> GetClusterPermissionLevels(string clusterId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/clusters/{clusterId}/permissionLevels";
-                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<AclPermissionItem>> GetClusterPermissions(string clusterId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/clusters/{clusterId}";
-                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<(PermissionLevel, string description)>> GetDirectoryPermissionLevels(string directoryId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/directories/{directoryId}/permissionLevels";
-                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<AclPermissionItem>> GetDirectoryPermissions(string directoryId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/directories/{directoryId}";
-                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<(PermissionLevel, string description)>> GetExperimentPermissionLevels(string experimentId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/experiments/{experimentId}/permissionLevels";
-                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<AclPermissionItem>> GetExperimentPermissions(string experimentId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/experiments/{experimentId}";
-                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<(PermissionLevel, string description)>> GetInstancePoolPermissionLevels(string instancePoolId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/instance-pools/{instancePoolId}/permissionLevels";
-                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<AclPermissionItem>> GetInstancePoolPermissions(string instancePoolId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/instance-pools/{instancePoolId}";
-                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<(PermissionLevel, string description)>> GetJobPermissionLevels(string jobId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/jobs/{jobId}/permissionLevels";
-                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<AclPermissionItem>> GetJobPermissions(string jobId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/jobs/{jobId}";
-                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<(PermissionLevel, string description)>> GetNotebookPermissionLevels(string notebookId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/notebooks/{notebookId}/permissionLevels";
-                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<AclPermissionItem>> GetNotebookPermissions(string notebookId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/notebooks/{notebookId}";
-                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<(PermissionLevel, string description)>> GetPipelinePermissionLevels(string pipelineId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/pipelines/{pipelineId}/permissionLevels";
-                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<AclPermissionItem>> GetPipelinePermissions(string pipelineId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/pipelines/{pipelineId}";
-                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<(PermissionLevel, string description)>> GetRegisteredModelPermissionLevels(string registeredModelId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/registered-models/{registeredModelId}/permissionLevels";
-                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<AclPermissionItem>> GetRegisteredModelPermissions(string registeredModelId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/registered-models/{registeredModelId}";
-                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<(PermissionLevel, string description)>> GetRepoPermissionLevels(string repoId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/repos/{repoId}/permissionLevels";
-                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<AclPermissionItem>> GetRepoPermissions(string repoId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/repos/{repoId}";
-                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<(PermissionLevel, string description)>> GetSqlWarehousePermissionLevels(string endpointId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/sql/endpoints/{endpointId}/permissionLevels";
-                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<AclPermissionItem>> GetSqlWarehousePermissions(string endpointId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/sql/endpoints/{endpointId}";
-                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<AclPermissionItem>> GetTokenPermissions(CancellationToken cancellationToken = default)
-                {
-                        const string requestUri = "permissions/authorization/tokens";
-                        return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task<IEnumerable<(PermissionLevel, string description)>> GetTokenPermissionsLevels(CancellationToken cancellationToken = default)
-                {
-                        const string requestUri = "permissions/authorization/tokens/permissionLevels";
-                        return await HttpGet<(PermissionLevel, string)[]>(HttpClient, requestUri, cancellationToken);
-                }
-
-                public async Task ReplaceClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/clusters/{clusterId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
-                }
-
-                public async Task ReplaceDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/directories/{directoryId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
-                }
-
-                public async Task ReplaceExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/experiments/{experimentId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
-                }
-
-                public async Task ReplaceInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/instance-pools/{instancePoolId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
-                }
-
-                public async Task ReplaceJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/jobs/{jobId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
-                }
-
-                public async Task ReplaceNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/notebooks/{notebookId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
-                }
-
-                public async Task ReplacePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/pipelines/{pipelineId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
-                }
-
-                public async Task ReplaceRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/registered-models/{registeredModelId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
-                }
-
-                public async Task ReplaceRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/repos/{repoId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
-                }
-
-                public async Task ReplaceSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/sql/endpoints/{endpointId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
-                }
-
-                public async Task ReplaceTokenPermissionsForWorkspace(IEnumerable<AclPermissionItem> AccessControlList, CancellationToken cancellationToken = default)
-                {
-                        const string requestUri = "permissions/authorization/tokens";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPut(HttpClient, requestUri, body, cancellationToken);
-                }
-
-                public async Task UpdateClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/clusters/{clusterId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPatch(HttpClient, requestUri, body);
-                }
-
-                public async Task UpdateDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/directories/{directoryId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPatch(HttpClient, requestUri, body);
-                }
-
-                public async Task UpdateExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/experiments/{experimentId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPatch(HttpClient, requestUri, body);
-                }
-
-                public async Task UpdateInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/instance-pools/{instancePoolId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPatch(HttpClient, requestUri, body);
-                }
-
-                public async Task UpdateJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/jobs/{jobId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPatch(HttpClient, requestUri, body);
-                }
-
-                public async Task UpdateNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/notebooks/{notebookId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPatch(HttpClient, requestUri, body);
-                }
-
-                public async Task UpdatePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/pipelines/{pipelineId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPatch(HttpClient, requestUri, body);
-                }
-
-                public async Task UpdateRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/registered-models/{registeredModelId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPatch(HttpClient, requestUri, body);
-                }
-
-                public async Task UpdateRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/repos/{repoId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPatch(HttpClient, requestUri, body);
-                }
-
-                public async Task UpdateSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId, CancellationToken cancellationToken = default)
-                {
-                        var requestUri = $"permissions/sql/endpoints/{endpointId}";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPatch(HttpClient, requestUri, body);
-                }
-
-                public async Task UpdateTokenPermissions(IEnumerable<AclPermissionItem> AccessControlList, CancellationToken cancellationToken = default)
-                {
-                        const string requestUri = "permissions/authorization/tokens";
-                        var body = new {access_control_list = AccessControlList};
-                        await HttpPatch(HttpClient, requestUri, body);
-                }
         }
+
+        public async Task<IEnumerable<AclPermissionDescription>> GetClusterPermissionLevels(string clusterId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/clusters/{clusterId}/permissionLevels";
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return PropertyExists(result, "permission_levels")
+                ? result.permission_levels.ToObject<IEnumerable<AclPermissionDescription>>()
+                : Enumerable.Empty<AclPermissionDescription>();
+        }
+
+        public async Task<IEnumerable<AclPermissionItem>> GetClusterPermissions(string clusterId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/clusters/{clusterId}";
+            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+        }
+
+        public async Task<IEnumerable<AclPermissionDescription>> GetDirectoryPermissionLevels(string directoryId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/directories/{directoryId}/permissionLevels";
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return PropertyExists(result, "permission_levels")
+                ? result.permission_levels.ToObject<IEnumerable<AclPermissionDescription>>()
+                : Enumerable.Empty<AclPermissionDescription>();
+        }
+
+        public async Task<IEnumerable<AclPermissionItem>> GetDirectoryPermissions(string directoryId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/directories/{directoryId}";
+            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+        }
+
+        public async Task<IEnumerable<AclPermissionDescription>> GetExperimentPermissionLevels(string experimentId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/experiments/{experimentId}/permissionLevels";
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return PropertyExists(result, "permission_levels")
+                ? result.permission_levels.ToObject<IEnumerable<AclPermissionDescription>>()
+                : Enumerable.Empty<AclPermissionDescription>();
+        }
+
+        public async Task<IEnumerable<AclPermissionItem>> GetExperimentPermissions(string experimentId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/experiments/{experimentId}";
+            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+        }
+
+        public async Task<IEnumerable<AclPermissionDescription>> GetInstancePoolPermissionLevels(string instancePoolId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/instance-pools/{instancePoolId}/permissionLevels";
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return PropertyExists(result, "permission_levels")
+                ? result.permission_levels.ToObject<IEnumerable<AclPermissionDescription>>()
+                : Enumerable.Empty<AclPermissionDescription>();
+        }
+
+        public async Task<IEnumerable<AclPermissionItem>> GetInstancePoolPermissions(string instancePoolId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/instance-pools/{instancePoolId}";
+            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+        }
+
+        public async Task<IEnumerable<AclPermissionDescription>> GetJobPermissionLevels(string jobId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/jobs/{jobId}/permissionLevels";
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return PropertyExists(result, "permission_levels")
+                ? result.permission_levels.ToObject<IEnumerable<AclPermissionDescription>>()
+                : Enumerable.Empty<AclPermissionDescription>();
+        }
+
+        public async Task<IEnumerable<AclPermissionItem>> GetJobPermissions(string jobId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/jobs/{jobId}";
+            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+        }
+
+        public async Task<IEnumerable<AclPermissionDescription>> GetNotebookPermissionLevels(string notebookId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/notebooks/{notebookId}/permissionLevels";
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return PropertyExists(result, "permission_levels")
+                ? result.permission_levels.ToObject<IEnumerable<AclPermissionDescription>>()
+                : Enumerable.Empty<AclPermissionDescription>();
+        }
+
+        public async Task<IEnumerable<AclPermissionItem>> GetNotebookPermissions(string notebookId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/notebooks/{notebookId}";
+            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+        }
+
+        public async Task<IEnumerable<AclPermissionDescription>> GetPipelinePermissionLevels(string pipelineId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/pipelines/{pipelineId}/permissionLevels";
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return PropertyExists(result, "permission_levels")
+                ? result.permission_levels.ToObject<IEnumerable<AclPermissionDescription>>()
+                : Enumerable.Empty<AclPermissionDescription>();
+        }
+
+        public async Task<IEnumerable<AclPermissionItem>> GetPipelinePermissions(string pipelineId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/pipelines/{pipelineId}";
+            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+        }
+
+        public async Task<IEnumerable<AclPermissionDescription>> GetRegisteredModelPermissionLevels(string registeredModelId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/registered-models/{registeredModelId}/permissionLevels";
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return PropertyExists(result, "permission_levels")
+                ? result.permission_levels.ToObject<IEnumerable<AclPermissionDescription>>()
+                : Enumerable.Empty<AclPermissionDescription>();
+        }
+
+        public async Task<IEnumerable<AclPermissionItem>> GetRegisteredModelPermissions(string registeredModelId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/registered-models/{registeredModelId}";
+            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+        }
+
+        public async Task<IEnumerable<AclPermissionDescription>> GetRepoPermissionLevels(string repoId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/repos/{repoId}/permissionLevels";
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return PropertyExists(result, "permission_levels")
+                ? result.permission_levels.ToObject<IEnumerable<AclPermissionDescription>>()
+                : Enumerable.Empty<AclPermissionDescription>();
+        }
+
+        public async Task<IEnumerable<AclPermissionItem>> GetRepoPermissions(string repoId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/repos/{repoId}";
+            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+        }
+
+        public async Task<IEnumerable<AclPermissionDescription>> GetSqlWarehousePermissionLevels(string endpointId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/sql/endpoints/{endpointId}/permissionLevels";
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return PropertyExists(result, "permission_levels")
+                ? result.permission_levels.ToObject<IEnumerable<AclPermissionDescription>>()
+                : Enumerable.Empty<AclPermissionDescription>();
+        }
+
+        public async Task<IEnumerable<AclPermissionItem>> GetSqlWarehousePermissions(string endpointId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/sql/endpoints/{endpointId}";
+            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+        }
+
+        public async Task<IEnumerable<AclPermissionItem>> GetTokenPermissions(CancellationToken cancellationToken = default)
+        {
+            const string requestUri = "permissions/authorization/tokens";
+            return await HttpGet<AclPermissionItem[]>(HttpClient, requestUri, cancellationToken);
+        }
+
+        public async Task<IEnumerable<AclPermissionDescription>> GetTokenPermissionsLevels(CancellationToken cancellationToken = default)
+        {
+            const string requestUri = "permissions/authorization/tokens/permissionLevels";
+            var result = await HttpGet<dynamic>(HttpClient, requestUri, cancellationToken);
+            return PropertyExists(result, "permission_levels")
+                ? result.permission_levels.ToObject<IEnumerable<AclPermissionDescription>>()
+                : Enumerable.Empty<AclPermissionDescription>();
+        }
+
+        public async Task ReplaceClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/clusters/{clusterId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPut(HttpClient, requestUri, body, cancellationToken);
+        }
+
+        public async Task ReplaceDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/directories/{directoryId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPut(HttpClient, requestUri, body, cancellationToken);
+        }
+
+        public async Task ReplaceExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/experiments/{experimentId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPut(HttpClient, requestUri, body, cancellationToken);
+        }
+
+        public async Task ReplaceInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/instance-pools/{instancePoolId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPut(HttpClient, requestUri, body, cancellationToken);
+        }
+
+        public async Task ReplaceJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/jobs/{jobId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPut(HttpClient, requestUri, body, cancellationToken);
+        }
+
+        public async Task ReplaceNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/notebooks/{notebookId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPut(HttpClient, requestUri, body, cancellationToken);
+        }
+
+        public async Task ReplacePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/pipelines/{pipelineId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPut(HttpClient, requestUri, body, cancellationToken);
+        }
+
+        public async Task ReplaceRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/registered-models/{registeredModelId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPut(HttpClient, requestUri, body, cancellationToken);
+        }
+
+        public async Task ReplaceRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/repos/{repoId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPut(HttpClient, requestUri, body, cancellationToken);
+        }
+
+        public async Task ReplaceSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/sql/endpoints/{endpointId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPut(HttpClient, requestUri, body, cancellationToken);
+        }
+
+        public async Task ReplaceTokenPermissionsForWorkspace(IEnumerable<AclPermissionItem> AccessControlList, CancellationToken cancellationToken = default)
+        {
+            const string requestUri = "permissions/authorization/tokens";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPut(HttpClient, requestUri, body, cancellationToken);
+        }
+
+        public async Task UpdateClusterPermissions(IEnumerable<AclPermissionItem> AccessControlList, string clusterId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/clusters/{clusterId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPatch(HttpClient, requestUri, body);
+        }
+
+        public async Task UpdateDirectoryPermissions(IEnumerable<AclPermissionItem> AccessControlList, string directoryId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/directories/{directoryId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPatch(HttpClient, requestUri, body);
+        }
+
+        public async Task UpdateExperimentPermissions(IEnumerable<AclPermissionItem> AccessControlList, string experimentId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/experiments/{experimentId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPatch(HttpClient, requestUri, body);
+        }
+
+        public async Task UpdateInstancePoolPermissions(IEnumerable<AclPermissionItem> AccessControlList, string instancePoolId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/instance-pools/{instancePoolId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPatch(HttpClient, requestUri, body);
+        }
+
+        public async Task UpdateJobPermissions(IEnumerable<AclPermissionItem> AccessControlList, string jobId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/jobs/{jobId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPatch(HttpClient, requestUri, body);
+        }
+
+        public async Task UpdateNotebookPermissions(IEnumerable<AclPermissionItem> AccessControlList, string notebookId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/notebooks/{notebookId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPatch(HttpClient, requestUri, body);
+        }
+
+        public async Task UpdatePipelinePermissions(IEnumerable<AclPermissionItem> AccessControlList, string pipelineId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/pipelines/{pipelineId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPatch(HttpClient, requestUri, body);
+        }
+
+        public async Task UpdateRegisteredModelPermissions(IEnumerable<AclPermissionItem> AccessControlList, string registeredModelId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/registered-models/{registeredModelId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPatch(HttpClient, requestUri, body);
+        }
+
+        public async Task UpdateRepoPermissions(IEnumerable<AclPermissionItem> AccessControlList, string repoId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/repos/{repoId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPatch(HttpClient, requestUri, body);
+        }
+
+        public async Task UpdateSqlWarehousePermissions(IEnumerable<AclPermissionItem> AccessControlList, string endpointId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"permissions/sql/endpoints/{endpointId}";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPatch(HttpClient, requestUri, body);
+        }
+
+        public async Task UpdateTokenPermissions(IEnumerable<AclPermissionItem> AccessControlList, CancellationToken cancellationToken = default)
+        {
+            const string requestUri = "permissions/authorization/tokens";
+            var body = new {access_control_list = AccessControlList};
+            await HttpPatch(HttpClient, requestUri, body);
+        }
+    }
 }

--- a/csharp/Microsoft.Azure.Databricks.Client/ServicePrincipalAclItem.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/ServicePrincipalAclItem.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Databricks.Client
 {
@@ -7,13 +8,7 @@ namespace Microsoft.Azure.Databricks.Client
     /// </summary>
     public class ServicePrincipalAclItem : AclPermissionItem
     {
-        internal override Dictionary<string, string> ToDictionaryRepresentation()
-        {
-            return new Dictionary<string, string>
-            {
-                {"service_principal_name", Principal},
-                {"permission_level", Permission.ToString()}
-            };
-        }
+        [JsonProperty("service_principal_name")]
+        public override string Principal { get => base.Principal; set => base.Principal = value; }
     }
 }

--- a/csharp/Microsoft.Azure.Databricks.Client/ServicePrincipalAclItem.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/ServicePrincipalAclItem.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.Databricks.Client
+{
+    /// <summary>
+    /// An item representing an ACL rule applied to a specific service principal. To be used when updated permission levels through the permissions Api
+    /// </summary>
+    public class ServicePrincipalAclItem : AclPermissionItem
+    {
+        internal override Dictionary<string, string> ToDictionaryRepresentation()
+        {
+            return new Dictionary<string, string>
+            {
+                {"service_principal_name", Principal},
+                {"permission_level", Permission.ToString()}
+            };
+        }
+    }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/UserAclItem.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/UserAclItem.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.Databricks.Client
+{
+    /// <summary>
+    /// An item representing an ACL rule applied to a specific user. To be used when updated permission levels through the permissions Api
+    /// </summary>
+    public class UserAclItem : AclPermissionItem
+    {
+        internal override Dictionary<string, string> ToDictionaryRepresentation()
+        {
+            return new Dictionary<string, string>
+            {
+                {"user_name", Principal},
+                {"permission_level", Permission.ToString()}
+            };
+        }
+    }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/UserAclItem.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/UserAclItem.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Databricks.Client
 {
@@ -7,13 +8,7 @@ namespace Microsoft.Azure.Databricks.Client
     /// </summary>
     public class UserAclItem : AclPermissionItem
     {
-        internal override Dictionary<string, string> ToDictionaryRepresentation()
-        {
-            return new Dictionary<string, string>
-            {
-                {"user_name", Principal},
-                {"permission_level", Permission.ToString()}
-            };
-        }
+        [JsonProperty("user_name")]
+        public override string Principal { get => base.Principal; set => base.Principal = value; }
     }
 }

--- a/csharp/Sample/Program.cs
+++ b/csharp/Sample/Program.cs
@@ -618,7 +618,15 @@ namespace Sample
             await WorkspacePermissions(client);
             await TokenPermissions(client);
             await ClusterPermissions(client);
-            //clusters
+            await PoolPermissions(client);
+            await JobPermissions(client);
+            await PipelinePermissions(client);
+            await NotebookPermissions(client);
+            await DirectoryPermissions(client);
+            await ExperimentsPermissions(client);
+            await RegisteredModelsPermissions(client);
+            await SqlWarehousePermissions(client);
+            await RepoPermissions(client);
         }
 
         private static async Task WorkspacePermissions(DatabricksClient client)
@@ -626,8 +634,7 @@ namespace Sample
             Console.WriteLine("Creating a new workspace...");
             await client.Workspace.Mkdirs(SampleWorkspacePath);
             //get directory info because we need the id
-            var info = await client.Workspace.List(SampleWorkspacePath);
-            var dirInfo = info.First(x => x.Path == SampleWorkspacePath);
+            var dirInfo = await client.Workspace.GetStatus(SampleWorkspacePath);
             Console.WriteLine($"Getting and displaying the allowable permission levels for directory with id {dirInfo.ObjectId}");
             var allowablePermissions = await client.Permissions.GetDirectoryPermissionLevels(dirInfo.ObjectId.ToString());
             foreach (var x in allowablePermissions)
@@ -725,6 +732,51 @@ namespace Sample
             Console.WriteLine($"Permissions reset for cluster {clusterId}");
             await client.Clusters.Delete(clusterId);
             Console.WriteLine("Sample cluster removed");
+        }
+
+        private static Task PoolPermissions(DatabricksClient client)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static Task JobPermissions(DatabricksClient client)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static Task PipelinePermissions(DatabricksClient client)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static Task NotebookPermissions(DatabricksClient client)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static Task DirectoryPermissions(DatabricksClient client)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static Task ExperimentsPermissions(DatabricksClient client)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static Task RegisteredModelsPermissions(DatabricksClient client)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static Task SqlWarehousePermissions(DatabricksClient client)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static Task RepoPermissions(DatabricksClient client)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/csharp/Sample/Program.cs
+++ b/csharp/Sample/Program.cs
@@ -689,7 +689,7 @@ namespace Sample
             //only the getters are shown here, since updating these permissions might invalidate 
             //the token that we are currently using to connect in the first place.
             Console.WriteLine("Getting and displaying the allowable permission levels for databricks tokens...");
-            var allowablePermissions = await client.Permissions.GetTokenPermissionsLevels();
+            var allowablePermissions = await client.Permissions.GetTokenPermissionLevels();
             foreach (var x in allowablePermissions)
             {
                 Console.WriteLine(x.PermissionLevel);

--- a/csharp/Sample/Program.cs
+++ b/csharp/Sample/Program.cs
@@ -32,7 +32,7 @@ namespace Sample
         private static readonly string RegisteredModelId = null;
         
         //fill in an existing sql warehouse endpoint ID in the variable below if you wish to try out the permissions API 
-        //for a sql warehous in your workspace
+        //for a sql warehouse in your workspace
         private static readonly string SqlWareHouseEndpointId = null;
 
         //file in an existing repository id in the variable below if you wish to try out the permissions API


### PR DESCRIPTION
I've added the 44 endpoints for the permissions Api (2.0), using the same class/interface organization used elsewhere in the project. I've tested most of the endpoints using an actual databricks cluster. I wasn't able to test every endpoint since we haven't used some features in databricks and I simply don't know how to set up an example to test against.

Those endpoints are:
Delta live pipelines, ML flow experiments and registered models, and sql warehouse endpoints.

Since the responses and handling code are identical across all the other endpoints I've tried I'm fairly confident they will work as expected, and I have included sample code to try it out (simply provide an Id for the resource)