### PR TITLE
fix: JobsApiClient.List should use limit, offset and expandTasks

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client.Test/JobApiClientTest.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client.Test/JobApiClientTest.cs
@@ -536,6 +536,7 @@ public class JobApiClientTest : ApiClientTest
     public async Task TestList()
     {
         var apiUri = new Uri(JobsApiUri, "list");
+        var requestUri = new Uri(apiUri, "?limit=20&offset=0&expand_tasks=false");
 
         var expectedResponse = new JobList
         {
@@ -555,7 +556,7 @@ public class JobApiClientTest : ApiClientTest
 
         var handler = CreateMockHandler();
         handler
-            .SetupRequest(HttpMethod.Get, apiUri)
+            .SetupRequest(HttpMethod.Get, requestUri)
             .ReturnsResponse(HttpStatusCode.OK, JsonSerializer.Serialize(expectedResponse, Options), "application/json")
             .Verifiable();
 
@@ -573,7 +574,7 @@ public class JobApiClientTest : ApiClientTest
 
         handler.VerifyRequest(
             HttpMethod.Get,
-            apiUri,
+            requestUri,
             Times.Once()
         );
     }

--- a/csharp/Microsoft.Azure.Databricks.Client/JobsApiClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/JobsApiClient.cs
@@ -41,7 +41,17 @@ public class JobsApiClient : ApiClient, IJobsApi
     public async Task<JobList> List(int limit = 20, int offset = 0, bool expandTasks = false,
         CancellationToken cancellationToken = default)
     {
-        var requestUri = $"{ApiVersion}/jobs/list";
+        if (limit < 1 || limit > 25)
+        {
+            throw new ArgumentOutOfRangeException(nameof(limit), "limit must be between 1 and 25");
+        }
+
+        if (offset < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(offset), "offset must be greater than or equal to 0");
+        }
+
+        var requestUri = $"{ApiVersion}/jobs/list?limit={limit}&offset={offset}&expand_tasks={expandTasks.ToString().ToLowerInvariant()}";
         var response = await HttpGet<JsonObject>(this.HttpClient, requestUri, cancellationToken)
             .ConfigureAwait(false);
 


### PR DESCRIPTION
Signed-off-by: Jason Wang <jasowang@microsoft.com>