### PR TITLE
Bugfixes

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client.Test/LibrariesApiClientTest.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client.Test/LibrariesApiClientTest.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Databricks.Client.Models;
+using Moq;
+using Moq.Contrib.HttpClient;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Microsoft.Azure.Databricks.Client.Test;
+
+[TestClass]
+public class LibrariesApiClientTest : ApiClientTest
+{
+    private static readonly Uri LibrariesApiUri = new(BaseApiUri, "2.0/libraries/");
+
+    [TestMethod]
+    public async Task TestClusterStatus()
+    {
+        var apiUri = new Uri(LibrariesApiUri, "cluster-status");
+        const string expectedResponse = @"
+                {
+                    ""cluster_id"": ""1234-567890-reef123"",
+                    ""library_statuses"": [
+                        {
+                            ""library"": {
+                                ""egg"": ""dbfs:/libraries/some-library.egg""
+                            },
+                            ""status"": ""PENDING"",
+                            ""is_library_for_all_clusters"": false
+                        },
+                        {
+                            ""library"": {
+                                ""maven"": {
+                                    ""coordinates"": ""com.microsoft.azure:azure-sqldb-spark:1.0.2""
+                                }
+                            },
+                            ""status"": ""PENDING"",
+                            ""is_library_for_all_clusters"": false
+                        },
+                        {
+                            ""library"": {
+                                ""pypi"": {
+                                    ""package"": ""adal~=1.2.0""
+                                }
+                            },
+                            ""status"": ""PENDING"",
+                            ""is_library_for_all_clusters"": false
+                        },
+                        {
+                            ""library"": {
+                                ""pypi"": {
+                                    ""package"": ""matplotlib~=3.5.0""
+                                }
+                            },
+                            ""status"": ""PENDING"",
+                            ""is_library_for_all_clusters"": false
+                        }
+                    ]
+                }
+                ";
+
+        var libraryStatuses = JsonSerializer.Deserialize<JsonObject>(expectedResponse)!["library_statuses"];
+        var expected = libraryStatuses.Deserialize<IEnumerable<LibraryFullStatus>>(Options);
+
+        var handler = CreateMockHandler();
+        handler
+            .SetupRequest(HttpMethod.Get, new Uri(apiUri, "?cluster_id=1234-567890-reef123"))
+            .ReturnsResponse(HttpStatusCode.OK, expectedResponse, "application/json");
+
+        var hc = handler.CreateClient();
+        hc.BaseAddress = BaseApiUri;
+
+        using var client = new LibrariesApiClient(hc);
+        var actual = await client.ClusterStatus("1234-567890-reef123");
+
+        AssertJsonDeepEquals(
+            JsonSerializer.Serialize(expected, Options),
+            JsonSerializer.Serialize(actual, Options)
+        );
+
+        handler.VerifyRequest(
+            HttpMethod.Get,
+            new Uri(apiUri, "?cluster_id=1234-567890-reef123"),
+            Times.Once()
+        );
+    }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client.Test/WorkspaceApiClientTest.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client.Test/WorkspaceApiClientTest.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Databricks.Client.Models;
+using Moq;
+using Moq.Contrib.HttpClient;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Microsoft.Azure.Databricks.Client.Test;
+
+[TestClass]
+public class WorkspaceApiClientTest : ApiClientTest
+{
+    private static readonly Uri WorkspaceApiUri = new(BaseApiUri, "2.0/workspace/");
+
+    [TestMethod]
+    public async Task TestExport()
+    {
+        var apiUri = new Uri(WorkspaceApiUri, "export");
+        const string expectedResponse = @"
+                {
+                    ""content"": ""Ly8gRGF0YWJyaWNrcyBub3RlYm9vayBzb3VyY2UKMSsx""
+                }
+                ";
+
+        var expected = Convert.FromBase64String(
+            JsonSerializer.Deserialize<JsonObject>(expectedResponse, Options)!["content"]!.GetValue<string>());
+
+        var handler = CreateMockHandler();
+        handler
+            .SetupRequest(HttpMethod.Get, new Uri(apiUri, "?path=/notebook_path&format=SOURCE"))
+            .ReturnsResponse(HttpStatusCode.OK, expectedResponse, "application/json");
+
+        var hc = handler.CreateClient();
+        hc.BaseAddress = BaseApiUri;
+
+        using var client = new WorkspaceApiClient(hc);
+        var actual = await client.Export("/notebook_path", ExportFormat.SOURCE);
+
+        CollectionAssert.AreEqual(actual, expected);
+
+        handler.VerifyRequest(
+            HttpMethod.Get,
+            new Uri(apiUri, "?path=/notebook_path&format=SOURCE"),
+            Times.Once()
+        );
+    }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/LibrariesApiClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/LibrariesApiClient.cs
@@ -29,7 +29,7 @@ public class LibrariesApiClient : ApiClient, ILibrariesApi
                 .Deserialize<IEnumerable<JsonObject>>(Options)!
                 .ToDictionary(
                     e => e["cluster_id"].Deserialize<string>(Options),
-                    e => e["library_statuses"].Deserialize<IEnumerable<LibraryFullStatus>>(Options)
+                    e => e["library_statuses"].Deserialize<IEnumerable<LibraryFullStatus>>()
                 );
         }
         else
@@ -45,7 +45,7 @@ public class LibrariesApiClient : ApiClient, ILibrariesApi
         var result = await HttpGet<JsonObject>(this.HttpClient, url, cancellationToken).ConfigureAwait(false);
 
         return result.TryGetPropertyValue("library_statuses", out var libraryStatuses)
-            ? libraryStatuses.Deserialize<IEnumerable<LibraryFullStatus>>()
+            ? libraryStatuses.Deserialize<IEnumerable<LibraryFullStatus>>(Options)
             : Enumerable.Empty<LibraryFullStatus>();
     }
 

--- a/csharp/Microsoft.Azure.Databricks.Client/WorkspaceApiClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/WorkspaceApiClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Azure.Databricks.Client.Models;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -29,7 +30,7 @@ public class WorkspaceApiClient : ApiClient, IWorkspaceApi
     {
         var url = $"{ApiVersion}/workspace/export?path={path}&format={format}";
         var result = await HttpGet<JsonObject>(this.HttpClient, url, cancellationToken).ConfigureAwait(false);
-        return result["content"]!.AsValue().GetValue<byte[]>();
+        return Convert.FromBase64String(result["content"]!.GetValue<string>());
     }
 
     public async Task<ObjectInfo> GetStatus(string path, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Fix for two methods:
- LibrariesApi:ClusterStatus - unable to deserialize api reponse due to missing JsonSerializerOptions
- WorkspaceApi:Export - unable to convert base 64 string response to byte array

Unit tests added to cover fixes