### PR TITLE
Add jobsettings run_as object parameter

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/Models/JobSettings.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/JobSettings.cs
@@ -217,6 +217,12 @@ public record JobSettings : JobRunBaseSettings<JobTaskSettings>
     /// </summary>
     [JsonPropertyName("format")]
     public JobFormat Format { get; set; }
+
+    /// <summary>
+    /// Write-only setting, available only in Create/Update/Reset and Submit calls. Specifies the user or service principal that the job runs as. If not specified, the job runs as the user who created the job.
+    /// </summary>
+    [JsonPropertyName("run_as")]
+    public RunAs RunAs { get; set; }
 }
 
 /// <summary>

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/RunAs.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/RunAs.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Azure.Databricks.Client.Models;
+
+public sealed record RunAs
+{
+    /// <summary>
+    /// The email of an active workspace user. Non-admin users can only set this field to their own email.
+    /// </summary>
+    [JsonPropertyName("user_name")]
+    public string UserName { get; set; }
+
+    /// <summary>
+    /// Application ID of an active service principal. Setting this field requires the servicePrincipal/user role.
+    /// </summary>
+    [JsonPropertyName("service_principal_name")]
+    public string ServicePrincipalName { get; set; }
+}


### PR DESCRIPTION
Enable job creation and reset to specify a **run_as** object, in order to control who runs and creates jobs.

According to 2.1 [databricks spec](https://docs.databricks.com/api/workspace/jobs/create)