### PR TITLE
make RuntimeEngine nullable for proper serialization #143

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/Models/ClusterAttributes.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/ClusterAttributes.cs
@@ -156,7 +156,7 @@ public record ClusterAttributes : ClusterSize
     /// * STANDARD: Use the standard runtime engine type.
     /// </summary>
     [JsonPropertyName("runtime_engine")]
-    public RuntimeEngine RuntimeEngine { get; set; }
+    public RuntimeEngine? RuntimeEngine { get; set; }
 
     /// <summary>
     /// Specifies the single user's AAD user name, who is allowed to run commands on this cluster when Credential Passthrough is enabled.

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/ClusterAttributes.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/ClusterAttributes.cs
@@ -100,7 +100,7 @@ public record ClusterAttributes : ClusterSize
     /// Automatically terminates the cluster after it is inactive for this time in minutes. If not set, this cluster will not be automatically terminated. If specified, the threshold must be between 10 and 10000 minutes. Users can also set this value to 0 to explicitly disable automatic termination.
     /// </summary>
     [JsonPropertyName("autotermination_minutes")]
-    public int AutoTerminationMinutes { get; set; }
+    public int? AutoTerminationMinutes { get; set; }
 
     /// <summary>
     /// Autoscaling Local Storage: when enabled, this cluster will dynamically acquire additional disk space when its Spark workers are running low on disk space.


### PR DESCRIPTION
When creating a new ClusterAttributes object, if the runtime_enigne is being set to Photon it does not get serialized. I believe it is ignored in the ApiClient because of the JsonSerializerOptions where DefaultIgnoreCondition is set to JsonIgnoreCondition.WhenWritingDefault, and when setting that value to 0 (RuntimeEngine.Photon) it just ignores it. Setting it to RuntimeEngine.Standard (1) works.

I think the RuntimeEngine enum can be made nullable since the [API documentation](https://docs.databricks.com/api/azure/workspace/clusters/create) states that if left unspecified, the runtime engine is inferred from spark_version. 

Issue #143 