### PR TITLE
fix: Wrong page token parameter name in PipelinesApiClient

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/PipelinesApiClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/PipelinesApiClient.cs
@@ -28,7 +28,7 @@ public class PipelinesApiClient : ApiClient, IPipelinesApi
 
         if (!string.IsNullOrEmpty(pageToken))
         {
-            requestUriSb.Append($"&pageToken={pageToken}");
+            requestUriSb.Append($"&page_token={pageToken}");
         }
 
         var requestUri = requestUriSb.ToString();


### PR DESCRIPTION
fixes #169 