### PR TITLE
Deserialization exceptions when using foreign type unity catalog and foreign type tables

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/Catalog.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/Catalog.cs
@@ -95,7 +95,8 @@ public enum CatalogType
     MANAGED_CATALOG,
     DELTASHARING_CATALOG,
     SYSTEM_CATALOG,
-    INTERNAL_CATALOG
+    INTERNAL_CATALOG,
+    FOREIGN_CATALOG
 }
 
 public enum IsolationMode

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/Table.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/Table.cs
@@ -295,7 +295,8 @@ public enum TableType
     EXTERNAL,
     VIEW,
     MATERIALIZED_VIEW,
-    STREAMING_TABLE
+    STREAMING_TABLE,
+    FOREIGN
 }
 
 public enum DataSourceFormat
@@ -308,5 +309,6 @@ public enum DataSourceFormat
     ORC,
     TEXT,
     UNITY_CATALOG,
-    DELTASHARING
+    DELTASHARING,
+    POSTGRESQL_FORMAT
 }


### PR DESCRIPTION
When using Lakehouse Federation and there is any foreign catalog in Unity Catalog there are some errors in deserialization. 

- Deserialization to Catalog class 

`System.Text.Json.JsonException: The JSON value could not be converted to System.Nullable1[Microsoft.Azure.Databricks.Client.Models.UnityCatalog.CatalogType]. Path: $[4].catalog_type | LineNumber: 0 | BytePositionInLine: 2881.` 

- Deserialization to Table class

`System.Text.Json.JsonException: The JSON value could not be converted to System.Nullable1[Microsoft.Azure.Databricks.Client.Models.UnityCatalog.TableType]. Path: $[0].table_type | LineNumber: 0 | BytePositionInLine: 71. `
`System.Text.Json.JsonException: The JSON value could not be converted to System.Nullable1[Microsoft.Azure.Databricks.Client.Models.UnityCatalog.TableType]. Path: $[0].table_type | LineNumber: 0 | BytePositionInLine: 71. `

In this pull request I have added changes which I have added in my project to make this azure-databricks-client work. If you agree to add support for foreign catalogs I would be happy to test and make PR to support other available types (according to docs [What is Lakehouse Federation | Databricks on AWS](https://docs.databricks.com/en/query-federation/index.html) MySQL, PostgreSQL, Amazon Redshift, Snowflake, Microsoft SQL Server, Azure Synapse, Google BigQuery, Databricks)