### PR TITLE
Make top-level client properties virtual to enable mocking

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/DatabricksClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/DatabricksClient.cs
@@ -138,37 +138,37 @@ public class DatabricksClient : IDisposable
         return new DatabricksClient(baseUrl, workspaceResourceId, databricksToken, managementToken, timeoutSeconds, httpClientConfig);
     }
 
-    public IClustersApi Clusters { get; }
+    public virtual IClustersApi Clusters { get; }
 
-    public IJobsApi Jobs { get; }
+    public virtual IJobsApi Jobs { get; }
 
-    public IDbfsApi Dbfs { get; }
+    public virtual IDbfsApi Dbfs { get; }
 
-    public ISecretsApi Secrets { get; }
+    public virtual ISecretsApi Secrets { get; }
 
-    public IGroupsApi Groups { get; }
+    public virtual IGroupsApi Groups { get; }
 
-    public ILibrariesApi Libraries { get; }
+    public virtual ILibrariesApi Libraries { get; }
 
-    public ITokenApi Token { get; }
+    public virtual ITokenApi Token { get; }
 
-    public IWorkspaceApi Workspace { get; }
+    public virtual IWorkspaceApi Workspace { get; }
 
-    public IInstancePoolApi InstancePool { get; }
+    public virtual IInstancePoolApi InstancePool { get; }
 
-    public IPermissionsApi Permissions { get; }
+    public virtual IPermissionsApi Permissions { get; }
 
-    public IClusterPoliciesApi ClusterPolicies { get; }
+    public virtual IClusterPoliciesApi ClusterPolicies { get; }
 
-    public IGlobalInitScriptsApi GlobalInitScriptsApi { get; }
+    public virtual IGlobalInitScriptsApi GlobalInitScriptsApi { get; }
 
-    public ISQLApi SQL { get; }
+    public virtual ISQLApi SQL { get; }
 
-    public IReposApi Repos { get; }
+    public virtual IReposApi Repos { get; }
 
-    public IPipelinesApi Pipelines { get; }
+    public virtual IPipelinesApi Pipelines { get; }
 
-    public UnityCatalogClient UnityCatalog { get; }
+    public virtual UnityCatalogClient UnityCatalog { get; }
 
     public void Dispose()
     {

--- a/csharp/Microsoft.Azure.Databricks.Client/UnityCatalogClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/UnityCatalogClient.cs
@@ -25,31 +25,31 @@ public class UnityCatalogClient : ApiClient, IDisposable
         this.Lineage = new LineageApiClient(httpClient);
     }
 
-    public ICatalogsApi Catalogs { get; set; }
+    public virtual ICatalogsApi Catalogs { get; set; }
 
-    public IConnectionsApi Connections { get; set; }
+    public virtual IConnectionsApi Connections { get; set; }
 
-    public IExternalLocationsApi ExternalLocations { get; set; }
+    public virtual IExternalLocationsApi ExternalLocations { get; set; }
 
-    public IFunctionsApi Functions { get; set; }
+    public virtual IFunctionsApi Functions { get; set; }
 
-    public IMetastoresApi Metastores { get; set; }
+    public virtual IMetastoresApi Metastores { get; set; }
 
-    public ISchemasApi Schemas { get; set; }
+    public virtual ISchemasApi Schemas { get; set; }
 
-    public ISecurableWorkspaceBindingsApi SecurableWorkspaceBindings { get; set; }
+    public virtual ISecurableWorkspaceBindingsApi SecurableWorkspaceBindings { get; set; }
 
-    public IStorageCredentialsApi StorageCredentials { get; set; }
+    public virtual IStorageCredentialsApi StorageCredentials { get; set; }
 
-    public ISystemSchemas SystemSchemas { get; set; }
+    public virtual ISystemSchemas SystemSchemas { get; set; }
 
-    public ITableConstraintsApi TableConstraints { get; set; }
+    public virtual ITableConstraintsApi TableConstraints { get; set; }
 
-    public ITablesApi Tables { get; set; }
+    public virtual ITablesApi Tables { get; set; }
 
-    public IUnityCatalogPermissionsApi UnityCatalogPermissions { get; set; }
+    public virtual IUnityCatalogPermissionsApi UnityCatalogPermissions { get; set; }
 
-    public IVolumesApi Volumes { get; set; }
+    public virtual IVolumesApi Volumes { get; set; }
 
-    public ILineageApi Lineage { get; set; }
+    public virtual ILineageApi Lineage { get; set; }
 }


### PR DESCRIPTION
Change DatabricksClient sub-client properties to be virtual so that they can be mocked in testing scenarios. Also do the same for UnityCatalogClient because that one follows same pattern of individual clients.

Should achieve the same end result as mentioned in #107.