### PR TITLE
Added Models for Run Status

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client.Test/JobApiClientTest.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client.Test/JobApiClientTest.cs
@@ -943,7 +943,15 @@ public class JobApiClientTest : ApiClientTest
                         988297789683452
                       ]
                     }
-                  ]
+                  ],
+                ""status"": {
+                ""state"": ""TERMINATED"",
+                ""termination_details"": {
+                    ""code"": ""RUN_EXECUTION_ERROR"",
+                    ""type"": ""CLIENT_ERROR"",
+                    ""message"": ""Task deliver_lineitems failed with message: Workload failed, see run output for details. This caused all downstream tasks to get skipped.""
+                }
+            }
                 }
         ";
 
@@ -1006,7 +1014,17 @@ public class JobApiClientTest : ApiClientTest
             RunName = "A multitask job run",
             RunPageUrl = "https://my-workspace.cloud.databricks.com/#job/39832/run/20",
             RunType = RunType.JOB_RUN,
-            AttemptNumber = 0
+            AttemptNumber = 0,
+            Status = new RunStatus
+            {
+                State = RunStatusState.TERMINATED,
+                TerminationDetails = new TerminationDetails
+                {
+                    Code = RunTerminationCode.RUN_EXECUTION_ERROR,
+                    Type = TerminationType.CLIENT_ERROR,
+                    Message = "Task deliver_lineitems failed with message: Workload failed, see run output for details. This caused all downstream tasks to get skipped."
+                }
+            }
         };
 
         var expectedRepair = new RepairHistory

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/QueueCode.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/QueueCode.cs
@@ -1,0 +1,22 @@
+﻿namespace Microsoft.Azure.Databricks.Client.Models;
+
+/// <summary>
+/// Provides the reason for queuing the run.
+/// </summary>
+public enum QueueCode
+{
+    /// <summary>
+    /// The run was queued due to reaching the workspace limit of active task runs.
+    /// </summary>
+    ACTIVE_RUNS_LIMIT_REACHED,
+
+    /// <summary>
+    /// The run was queued due to reaching the per-job limit of concurrent job runs.
+    /// </summary>
+    MAX_CONCURRENT_RUNS_REACHED,
+
+    /// <summary>
+    /// The run was queued due to reaching the workspace limit of active run job tasks.
+    /// </summary>
+    ACTIVE_RUN_JOB_TASKS_LIMIT_REACHED
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/QueueDetails.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/QueueDetails.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Microsoft.Azure.Databricks.Client.Models;
+
+/// <summary>
+/// If the run was queued, provides the details for queuing the run.
+/// </summary>
+public class QueueDetails
+{
+    /// <summary>
+    /// The reason for queuing the run.
+    /// </summary>
+    [JsonPropertyName("code")]
+    public QueueCode Code { get; set; }
+
+    /// <summary>
+    /// A descriptive message with the queuing details. This field is unstructured, and its exact format is subject to change.
+    /// </summary>
+    [JsonPropertyName("message")]
+    public string Message { get; set; }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/Run.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/Run.cs
@@ -199,6 +199,12 @@ public record Run : RunIdentifier
     public RunState State { get; set; }
 
     /// <summary>
+    /// The current status of the run
+    /// </summary>
+    [JsonPropertyName("status")]
+    public RunStatus Status { get; set; }
+
+    /// <summary>
     /// The cron schedule that triggered this run if it was triggered by the periodic scheduler.
     /// </summary>
     [JsonPropertyName("schedule")]

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/Run.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/Run.cs
@@ -195,6 +195,7 @@ public record Run : RunIdentifier
     /// <summary>
     /// The result and lifecycle states of the run.
     /// </summary>
+    [Obsolete("This property is deprecated. Please use Status instead.")]
     [JsonPropertyName("state")]
     public RunState State { get; set; }
 

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/RunStatus.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/RunStatus.cs
@@ -1,0 +1,27 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Microsoft.Azure.Databricks.Client.Models;
+
+/// <summary>
+/// Provides details around the current status of the run.
+/// </summary>
+public class RunStatus
+{
+    /// <summary>
+    /// The current state of the run.
+    /// </summary>
+    [JsonPropertyName("state")]
+    public RunStatusState State { get; set; }
+
+    /// <summary>
+    /// If the run is in a TERMINATING or TERMINATED state, details about the reason for terminating the run.
+    /// </summary>
+    [JsonPropertyName("termination_details")]
+    public TerminationDetails? TerminationDetails { get; set; }
+
+    /// <summary>
+    /// If the run was queued, details about the reason for queuing the run.
+    /// </summary>
+    [JsonPropertyName("queue_details")]
+    public QueueDetails? QueueDetails { get; set; }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/RunStatusState.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/RunStatusState.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.Azure.Databricks.Client.Models;
+
+public enum RunStatusState
+{
+    BLOCKED,
+    PENDING,
+    QUEUED,
+    RUNNING,
+    TERMINATING,
+    TERMINATED
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/RunTerminationCode.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/RunTerminationCode.cs
@@ -1,0 +1,112 @@
+﻿namespace Microsoft.Azure.Databricks.Client.Models;
+
+/// <summary>
+/// A value indicating the run's current state.
+/// </summary>
+public enum RunTerminationCode
+{
+    /// <summary>
+    /// The run was completed successfully.
+    /// </summary>
+    SUCCESS,
+
+    /// <summary>
+    /// The run was canceled during execution by the Azure Databricks platform; for example, if the maximum run duration was exceeded.
+    /// </summary>
+    CANCELED,
+
+    /// <summary>
+    /// Run was never executed, for example, if the upstream task run failed, the dependency type condition was not met, or there were no material tasks to execute.
+    /// </summary>
+    SKIPPED,
+
+    /// <summary>
+    /// The run encountered an unexpected error. Refer to the state message for further details.
+    /// </summary>
+    INTERNAL_ERROR,
+
+    /// <summary>
+    /// The run encountered an error while communicating with the Spark Driver.
+    /// </summary>
+    DRIVER_ERROR,
+
+    /// <summary>
+    /// The run failed due to a cluster error. Refer to the state message for further details.
+    /// </summary>
+    CLUSTER_ERROR,
+
+    /// <summary>
+    /// Failed to complete the checkout due to an error when communicating with the third party service.
+    /// </summary>
+    REPOSITORY_CHECKOUT_FAILED,
+
+    /// <summary>
+    /// The run failed because it issued an invalid request to start the cluster.
+    /// </summary>
+    INVALID_CLUSTER_REQUEST,
+
+    /// <summary>
+    /// The workspace has reached the quota for the maximum number of concurrent active runs. Consider scheduling the runs over a larger time frame.
+    /// </summary>
+    WORKSPACE_RUN_LIMIT_EXCEEDED,
+
+    /// <summary>
+    /// The run failed because it tried to access a feature unavailable for the workspace.
+    /// </summary>
+    FEATURE_DISABLED,
+
+    /// <summary>
+    /// The number of cluster creation, start, and upsize requests have exceeded the allotted rate limit. Consider spreading the run execution over a larger time frame.
+    /// </summary>
+    CLUSTER_REQUEST_LIMIT_EXCEEDED,
+
+    /// <summary>
+    /// The run failed due to an error when accessing the customer blob storage. Refer to the state message for further details.
+    /// </summary>
+    STORAGE_ACCESS_ERROR,
+
+    /// <summary>
+    /// The run was completed with task failures. For more details, refer to the state message or run output.
+    /// </summary>
+    RUN_EXECUTION_ERROR,
+
+    /// <summary>
+    /// The run failed due to a permission issue while accessing a resource. Refer to the state message for further details.
+    /// </summary>
+    UNAUTHORIZED_ERROR,
+
+    /// <summary>
+    /// The run failed while installing the user-requested library. Refer to the state message for further details. The causes might include, but are not limited to: The provided library is invalid, there are insufficient permissions to install the library, and so forth.
+    /// </summary>
+    LIBRARY_INSTALLATION_ERROR,
+
+    /// <summary>
+    /// The scheduled run exceeds the limit of maximum concurrent runs set for the job.
+    /// </summary>
+    MAX_CONCURRENT_RUNS_EXCEEDED,
+
+    /// <summary>
+    /// The run is scheduled on a cluster that has already reached the maximum number of contexts it is configured to create.
+    /// </summary>
+    MAX_SPARK_CONTEXTS_EXCEEDED,
+
+    /// <summary>
+    /// A resource necessary for run execution does not exist. Refer to the state message for further details.
+    /// </summary>
+    RESOURCE_NOT_FOUND,
+
+    /// <summary>
+    /// The run failed due to an invalid configuration. Refer to the state message for further details.
+    /// </summary>
+    INVALID_RUN_CONFIGURATION,
+
+    /// <summary>
+    /// The run failed due to a cloud provider issue. Refer to the state message for further details.
+    /// </summary>
+    CLOUD_FAILURE,
+
+    /// <summary>
+    /// The run was skipped due to reaching the job level queue size limit.
+    /// </summary>
+    MAX_JOB_QUEUE_SIZE_EXCEEDED
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/TerminationDetails.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/TerminationDetails.cs
@@ -1,0 +1,27 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Microsoft.Azure.Databricks.Client.Models;
+
+/// <summary>
+/// Provides the details of a run that is in a TERMINATING or TERMINATED state.
+/// </summary>
+public class TerminationDetails
+{
+    /// <summary>
+    /// The code indicates why the run was terminated.
+    /// </summary>
+    [JsonPropertyName("code")]
+    public RunTerminationCode Code { get; set; }
+
+    /// <summary>
+    /// The describes the overall termination type.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public TerminationType Type { get; set; }
+
+    /// <summary>
+    /// A descriptive message with the queuing details. This field is unstructured, and its exact format is subject to change.
+    /// </summary>
+    [JsonPropertyName("message")]
+    public string Message { get; set; }
+}


### PR DESCRIPTION
The current Run object is missing the Status object and related child objects.   Per the documentation the state is deprecated, therefore in addition to adding the Status objects I have also annotated the State property as Obsolete to generate a compiler warning only.

Documentation found here:
https://docs.databricks.com/api/azure/workspace/jobs/listruns#runs-status-termination_details 

#211 