### PR TITLE
Clean up build warnings

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client.Sample/SampleProgram.Jobs.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client.Sample/SampleProgram.Jobs.cs
@@ -64,12 +64,12 @@ internal static partial class SampleProgram
         {
             EmailNotifications = new JobEmailNotifications
             {
-                OnSuccess = new[] { "someone@example.com" }
+                OnSuccess = ["someone@example.com"]
             }
         });
 
         // Removing email notifications and libraries.
-        await client.Jobs.Update(jobId, null, new[] { "email_notifications" });
+        await client.Jobs.Update(jobId, null, ["email_notifications"]);
 
 
         // Reset job by pausing schedule and attaching libraries to each task.
@@ -123,6 +123,7 @@ internal static partial class SampleProgram
         await client.Workspace.Delete(SampleWorkspacePath, true);
     }
 
+#pragma warning disable CS0618 // Type or member is obsolete
     private static async Task WaitForRun(IJobsApi jobClient, long runId, int pollIntervalSeconds = 15)
     {
         var retryPolicy = Policy.Handle<WebException>()
@@ -151,7 +152,6 @@ internal static partial class SampleProgram
             Console.WriteLine(
                 $"[{DateTime.UtcNow:s}]Run:{runId}\tLifeCycleState:{run.State.LifeCycleState}\tResultState:{run.State.ResultState}\tCompleted:{run.IsCompleted}"
             );
-
             return run.State;
         });
     }

--- a/csharp/Microsoft.Azure.Databricks.Client.Test/JobApiClientTest.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client.Test/JobApiClientTest.cs
@@ -955,6 +955,7 @@ public class JobApiClientTest : ApiClientTest
                 }
         ";
 
+#pragma warning disable CS0618 // Type or member is obsolete
         var expectedRun = new Run
         {
             JobId = 11223344,
@@ -1021,11 +1022,12 @@ public class JobApiClientTest : ApiClientTest
                 TerminationDetails = new TerminationDetails
                 {
                     Code = RunTerminationCode.RUN_EXECUTION_ERROR,
-                    Type = TerminationType.CLIENT_ERROR,
+                    Type = RunTerminationType.CLIENT_ERROR,
                     Message = "Task deliver_lineitems failed with message: Workload failed, see run output for details. This caused all downstream tasks to get skipped."
                 }
             }
         };
+#pragma warning restore CS0618 // Type or member is obsolete
 
         var expectedRepair = new RepairHistory
         {

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/Run.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/Run.cs
@@ -323,5 +323,5 @@ public record Run : RunIdentifier
     /// Indication if the run has been completed.
     /// </summary>
     [JsonIgnore]
-    public bool IsCompleted => State?.ResultState != null;
+    public bool IsCompleted => Status.State == RunStatusState.TERMINATED;
 }

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/RunStatus.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/RunStatus.cs
@@ -17,11 +17,11 @@ public class RunStatus
     /// If the run is in a TERMINATING or TERMINATED state, details about the reason for terminating the run.
     /// </summary>
     [JsonPropertyName("termination_details")]
-    public TerminationDetails? TerminationDetails { get; set; }
+    public TerminationDetails TerminationDetails { get; set; }
 
     /// <summary>
     /// If the run was queued, details about the reason for queuing the run.
     /// </summary>
     [JsonPropertyName("queue_details")]
-    public QueueDetails? QueueDetails { get; set; }
+    public QueueDetails QueueDetails { get; set; }
 }

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/TerminationDetails.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/TerminationDetails.cs
@@ -17,11 +17,19 @@ public class TerminationDetails
     /// The describes the overall termination type.
     /// </summary>
     [JsonPropertyName("type")]
-    public TerminationType Type { get; set; }
+    public RunTerminationType Type { get; set; }
 
     /// <summary>
     /// A descriptive message with the queuing details. This field is unstructured, and its exact format is subject to change.
     /// </summary>
     [JsonPropertyName("message")]
     public string Message { get; set; }
+}
+
+public enum RunTerminationType
+{
+    SUCCESS,
+    INTERNAL_ERROR,
+    CLIENT_ERROR,
+    CLOUD_FAILURE
 }


### PR DESCRIPTION
Clean up build warnings by removing nullable reference types for now.
Suppress Obsolete warnings as the usages are for testing.