### PR TITLE
Add GenerateDocumentationFile to make summaries show up in IDEs

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/Microsoft.Azure.Databricks.Client.csproj
+++ b/csharp/Microsoft.Azure.Databricks.Client/Microsoft.Azure.Databricks.Client.csproj
@@ -5,6 +5,7 @@
     <SignAssembly>true</SignAssembly>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1570,1573,1587,1591</NoWarn>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>

--- a/csharp/Microsoft.Azure.Databricks.Client/Microsoft.Azure.Databricks.Client.csproj
+++ b/csharp/Microsoft.Azure.Databricks.Client/Microsoft.Azure.Databricks.Client.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>


### PR DESCRIPTION
Without `GenerateDocumentationFile` set to true, your great code summaries never make it to the developer using the nuget.