### PR TITLE
Update JobsApiClient.cs

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/JobsApiClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/JobsApiClient.cs
@@ -221,11 +221,6 @@ public class JobsApiClient : ApiClient, IJobsApi
     {
         string url = BuildRunsListUrl(jobId, limit, activeOnly, completedOnly, runType, expandTasks, startTimeFrom, startTimeTo);
         url += string.IsNullOrEmpty(pageToken) ? string.Empty : $"&page_token={pageToken}";
-
-
-        await Console.Out.WriteLineAsync("Request: " + url);
-
-
         return await HttpGet<RunList>(this.HttpClient, url, cancellationToken).ConfigureAwait(false);
     }
 


### PR DESCRIPTION
Remove "await Console.Out.WriteLineAsync("Request: " + url);"

It seems to be left from some early testing. Or is there an actual reason to have it in only one RunsList function?