### PR TITLE
Update and remove unused packages

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client.Sample/Microsoft.Azure.Databricks.Client.Sample.csproj
+++ b/csharp/Microsoft.Azure.Databricks.Client.Sample/Microsoft.Azure.Databricks.Client.Sample.csproj
@@ -1,20 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <IsPackable>false</IsPackable>
+	<OutputType>Exe</OutputType>
+	<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+	<LangVersion>latest</LangVersion>
+	<IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Polly" Version="8.4.0" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+	<PackageReference Include="Azure.Identity" Version="1.13.0" />
+	<PackageReference Include="Polly" Version="8.4.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Azure.Databricks.Client\Microsoft.Azure.Databricks.Client.csproj" />
+	<ProjectReference Include="..\Microsoft.Azure.Databricks.Client\Microsoft.Azure.Databricks.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/csharp/Microsoft.Azure.Databricks.Client.Sample/Microsoft.Azure.Databricks.Client.Sample.csproj
+++ b/csharp/Microsoft.Azure.Databricks.Client.Sample/Microsoft.Azure.Databricks.Client.Sample.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<OutputType>Exe</OutputType>
-	<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
-	<LangVersion>latest</LangVersion>
-	<IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Azure.Identity" Version="1.13.0" />
-	<PackageReference Include="Polly" Version="8.4.2" />
+    <PackageReference Include="Azure.Identity" Version="1.13.0" />
+    <PackageReference Include="Polly" Version="8.4.2" />
   </ItemGroup>
 
   <ItemGroup>
-	<ProjectReference Include="..\Microsoft.Azure.Databricks.Client\Microsoft.Azure.Databricks.Client.csproj" />
+    <ProjectReference Include="..\Microsoft.Azure.Databricks.Client\Microsoft.Azure.Databricks.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/csharp/Microsoft.Azure.Databricks.Client.Test/Microsoft.Azure.Databricks.Client.Test.csproj
+++ b/csharp/Microsoft.Azure.Databricks.Client.Test/Microsoft.Azure.Databricks.Client.Test.csproj
@@ -1,27 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
+	<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+	<ImplicitUsings>enable</ImplicitUsings>
+	<Nullable>enable</Nullable>
+	<IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference> 
-    <PackageReference Include="Polly" Version="8.4.0" /> 
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+	<PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
+	<PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+	<PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+	<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PrivateAssets>all</PrivateAssets>
+		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	</PackageReference>
+	<PackageReference Include="Polly" Version="8.4.2" />
+	<PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Azure.Databricks.Client\Microsoft.Azure.Databricks.Client.csproj" />
+	<ProjectReference Include="..\Microsoft.Azure.Databricks.Client\Microsoft.Azure.Databricks.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/csharp/Microsoft.Azure.Databricks.Client.Test/Microsoft.Azure.Databricks.Client.Test.csproj
+++ b/csharp/Microsoft.Azure.Databricks.Client.Test/Microsoft.Azure.Databricks.Client.Test.csproj
@@ -1,27 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
-	<ImplicitUsings>enable</ImplicitUsings>
-	<Nullable>enable</Nullable>
-	<IsPackable>false</IsPackable>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-	<PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
-	<PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
-	<PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
-	<PackageReference Include="coverlet.collector" Version="6.0.2">
-		<PrivateAssets>all</PrivateAssets>
-		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
-	<PackageReference Include="Polly" Version="8.4.2" />
-	<PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="Polly" Version="8.4.2" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>
-	<ProjectReference Include="..\Microsoft.Azure.Databricks.Client\Microsoft.Azure.Databricks.Client.csproj" />
+    <ProjectReference Include="..\Microsoft.Azure.Databricks.Client\Microsoft.Azure.Databricks.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/csharp/Microsoft.Azure.Databricks.Client/DatabricksClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/DatabricksClient.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Core;
-using Azure.Identity;
 using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Threading.Tasks;
+
+using Azure.Core;
 
 namespace Microsoft.Azure.Databricks.Client;
 

--- a/csharp/Microsoft.Azure.Databricks.Client/Microsoft.Azure.Databricks.Client.csproj
+++ b/csharp/Microsoft.Azure.Databricks.Client/Microsoft.Azure.Databricks.Client.csproj
@@ -1,38 +1,38 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
-	<SignAssembly>true</SignAssembly>
-	<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-	<GenerateDocumentationFile>true</GenerateDocumentationFile>
-	<NoWarn>1573,1591</NoWarn>
-	<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-	<Company>Microsoft</Company>
-	<Authors>Microsoft</Authors>
-	<Description>Client library for managing Azure Databricks clusters and submitting jobs.</Description>
-	<RepositoryUrl>https://github.com/Azure/azure-databricks-client</RepositoryUrl>
-	<PackageTags>Databricks,Client</PackageTags>
-	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<PackageProjectUrl>https://github.com/Azure/azure-databricks-client</PackageProjectUrl>
-	<DelaySign>false</DelaySign>
-	<AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
-	<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-	<RepositoryType>git</RepositoryType>
-	<EnableNETAnalyzers>True</EnableNETAnalyzers>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
-	<VersionPrefix>2.1.1</VersionPrefix>
-	<IncludeSymbols>true</IncludeSymbols>
-	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <SignAssembly>true</SignAssembly>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1573,1591</NoWarn>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <Company>Microsoft</Company>
+    <Authors>Microsoft</Authors>
+    <Description>Client library for managing Azure Databricks clusters and submitting jobs.</Description>
+    <RepositoryUrl>https://github.com/Azure/azure-databricks-client</RepositoryUrl>
+    <PackageTags>Databricks,Client</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Azure/azure-databricks-client</PackageProjectUrl>
+    <DelaySign>false</DelaySign>
+    <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <RepositoryType>git</RepositoryType>
+    <EnableNETAnalyzers>True</EnableNETAnalyzers>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <VersionPrefix>2.1.1</VersionPrefix>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <Import Project="../../ReleaseNotes.props" />
   <ItemGroup>
-	<None Include="..\..\README.md">
-		<Pack>True</Pack>
-		<PackagePath>\</PackagePath>
-	</None>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="Azure.Core" Version="1.44.1" />
-	<PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="Azure.Core" Version="1.44.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 </Project>

--- a/csharp/Microsoft.Azure.Databricks.Client/Microsoft.Azure.Databricks.Client.csproj
+++ b/csharp/Microsoft.Azure.Databricks.Client/Microsoft.Azure.Databricks.Client.csproj
@@ -1,39 +1,38 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
-    <SignAssembly>true</SignAssembly>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>1573,1591</NoWarn>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Company>Microsoft</Company>
-    <Authors>Microsoft</Authors>
-    <Description>Client library for managing Azure Databricks clusters and submitting jobs.</Description>
-    <RepositoryUrl>https://github.com/Azure/azure-databricks-client</RepositoryUrl>
-    <PackageTags>Databricks,Client</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/Azure/azure-databricks-client</PackageProjectUrl>
-    <DelaySign>false</DelaySign>
-    <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
-    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <RepositoryType>git</RepositoryType>
-    <EnableNETAnalyzers>True</EnableNETAnalyzers>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <VersionPrefix>2.1.1</VersionPrefix>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+	<SignAssembly>true</SignAssembly>
+	<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+	<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	<NoWarn>1573,1591</NoWarn>
+	<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+	<Company>Microsoft</Company>
+	<Authors>Microsoft</Authors>
+	<Description>Client library for managing Azure Databricks clusters and submitting jobs.</Description>
+	<RepositoryUrl>https://github.com/Azure/azure-databricks-client</RepositoryUrl>
+	<PackageTags>Databricks,Client</PackageTags>
+	<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	<PackageProjectUrl>https://github.com/Azure/azure-databricks-client</PackageProjectUrl>
+	<DelaySign>false</DelaySign>
+	<AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
+	<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+	<RepositoryType>git</RepositoryType>
+	<EnableNETAnalyzers>True</EnableNETAnalyzers>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
+	<VersionPrefix>2.1.1</VersionPrefix>
+	<IncludeSymbols>true</IncludeSymbols>
+	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <Import Project="../../ReleaseNotes.props" />
   <ItemGroup>
-    <None Include="..\..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
+	<None Include="..\..\README.md">
+		<Pack>True</Pack>
+		<PackagePath>\</PackagePath>
+	</None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+	<PackageReference Include="Azure.Core" Version="1.44.1" />
+	<PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolves #231 

Azure.Identity is unused, only Azure.Core is needed (using reference removed from DatabricksClient).
System.Net.Http package is not needed as it is included in framework, removing cleans up the transitive dependencies.
Updates System.Text.Json to resolve security vulnerability in current version.

Overall transitive packages down from 61 to 8:

![image](https://github.com/user-attachments/assets/e92fca20-4139-405b-9374-4dee7a25d19a)

![image](https://github.com/user-attachments/assets/82e2b041-88af-40d7-b8f5-0b9cc2603db0)

If I have made any incorrect assumptions, please let me know.