### PR TITLE
fix: PipelinesApiClient.ListPageable() throws when no pipelines are returned

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/Models/PipelinesList.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/PipelinesList.cs
@@ -5,6 +5,11 @@ namespace Microsoft.Azure.Databricks.Client.Models;
 
 public class PipelinesList
 {
+    public PipelinesList()
+    {
+        this.Pipelines = new List<Pipeline>();
+    }
+
     /// <summary>
     /// The list of events matching the request criteria.
     /// </summary>


### PR DESCRIPTION
fixes #227 