### PR TITLE
Add Description property to JobSettings

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/Models/JobSettings.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/JobSettings.cs
@@ -190,6 +190,12 @@ public record JobSettings : JobRunBaseSettings<JobTaskSettings>
     /// </summary>
     [JsonPropertyName("name")]
     public string Name { get; set; }
+    
+    /// <summary>
+    /// An optional description for the job.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string Description { get; set; }
 
     /// <summary>
     /// A map of tags associated with the job. These are forwarded to the cluster as cluster tags for jobs clusters, and are subject to the same limitations as cluster tags. A maximum of 25 tags can be added to the job.

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/JobSettings.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/JobSettings.cs
@@ -190,7 +190,7 @@ public record JobSettings : JobRunBaseSettings<JobTaskSettings>
     /// </summary>
     [JsonPropertyName("name")]
     public string Name { get; set; }
-    
+
     /// <summary>
     /// An optional description for the job.
     /// </summary>


### PR DESCRIPTION
There is a job description property in API that is not supported in the SDK: 
![image](https://github.com/user-attachments/assets/a318b179-9aa4-49f5-b9bf-5ac0b3c82ce0)
