### PR TITLE
Add JobInfos to TablesLineage.cs

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/TablesLineage.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/TablesLineage.cs
@@ -19,6 +19,9 @@ public record ObjectsLineageStream
 
     [JsonPropertyName("pipelineInfos")]
     public IEnumerable<PipelineInfo> PipelineInfos { get; set; }
+
+    [JsonPropertyName("jobInfos")]
+    public IEnumerable<JobInfo> JobInfos { get; set; }
 }
 
 public record PipelineInfo
@@ -28,4 +31,13 @@ public record PipelineInfo
 
     [JsonPropertyName("update_id")]
     public string UpdateId { get; set; }
+}
+
+public record JobInfo
+{
+    [JsonPropertyName("workspace_id")]
+    public long WorkspaceId { get; set; }
+
+    [JsonPropertyName("job_id")]
+    public long JobId { get; set; }
 }


### PR DESCRIPTION
Lineage API returns information about jobs that is currently not supported:
 ![image](https://github.com/user-attachments/assets/be79fc03-4c4d-458e-8237-db1eb23c8600)

I added support for getting job information in tables lineage.

