### PR TITLE
Add support for UnityCatalog Shares API - fixes #258

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client.Test/UnityCatalog/SharesApiClientTest.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client.Test/UnityCatalog/SharesApiClientTest.cs
@@ -1,0 +1,504 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+using Microsoft.Azure.Databricks.Client.Models.UnityCatalog;
+using Microsoft.Azure.Databricks.Client.UnityCatalog;
+
+using Moq;
+using Moq.Contrib.HttpClient;
+
+namespace Microsoft.Azure.Databricks.Client.Test.UnityCatalog;
+
+[TestClass]
+public class SharesApiClientTest : UnityCatalogApiClientTest
+{
+    private static readonly Uri SharesApiUri = new(BaseApiUri, "shares");
+
+    [TestMethod]
+    public async Task TestList()
+    {
+        const string expectedResponse = @"
+        {
+          ""shares"": [
+            {
+              ""name"": ""string"",
+              ""owner"": ""string"",
+              ""comment"": ""string"",
+              ""storage_root"": ""string"",
+              ""objects"": [
+                {
+                  ""name"": ""string"",
+                  ""data_object_type"": ""TABLE"",
+                  ""added_at"": 0,
+                  ""added_by"": ""string"",
+                  ""comment"": ""string"",
+                  ""shared_as"": ""string"",
+                  ""partitions"": [
+                    {
+                      ""values"": [
+                        {
+                          ""name"": ""string"",
+                          ""value"": ""string"",
+                          ""recipient_property_key"": ""string"",
+                          ""op"": ""EQUAL""
+                        }
+                      ]
+                    }
+                  ],
+                  ""cdf_enabled"": true,
+                  ""history_data_sharing_status"": ""DISABLED"",
+                  ""start_version"": 0,
+                  ""status"": ""ACTIVE"",
+                  ""content"": ""string"",
+                  ""string_shared_as"": ""string""
+                }
+              ],
+              ""created_at"": 0,
+              ""created_by"": ""string"",
+              ""updated_at"": 0,
+              ""updated_by"": ""string"",
+              ""storage_location"": ""string""
+            }
+          ]
+        }
+";
+        var requestUri = SharesApiUri;
+
+        var handler = CreateMockHandler();
+        handler
+            .SetupRequest(HttpMethod.Get, requestUri)
+            .ReturnsResponse(HttpStatusCode.OK, expectedResponse, "application/json");
+
+        var mockClient = handler.CreateClient();
+        mockClient.BaseAddress = ApiClientTest.BaseApiUri;
+
+        using var client = new SharesApiClient(mockClient);
+        var actual = await client.List();
+        var responseObj = new { shares = actual };
+        var responseJson = JsonSerializer.Serialize(responseObj, Options);
+
+        AssertJsonDeepEquals(expectedResponse, responseJson);
+    }
+
+    [TestMethod]
+    public async Task TestCreate()
+    {
+        var expectedRequest = @"
+        {
+          ""name"": ""string"",
+          ""comment"": ""string"",
+          ""storage_root"": ""string""
+        }
+        ";
+
+        var expectedResponse = @"
+        {
+          ""name"": ""string"",
+          ""owner"": ""string"",
+          ""comment"": ""string"",
+          ""storage_root"": ""string"",
+          ""objects"": [
+            {
+              ""name"": ""string"",
+              ""data_object_type"": ""TABLE"",
+              ""added_at"": 0,
+              ""added_by"": ""string"",
+              ""comment"": ""string"",
+              ""shared_as"": ""string"",
+              ""partitions"": [
+                {
+                  ""values"": [
+                    {
+                      ""name"": ""string"",
+                      ""value"": ""string"",
+                      ""recipient_property_key"": ""string"",
+                      ""op"": ""EQUAL""
+                    }
+                  ]
+                }
+              ],
+              ""cdf_enabled"": true,
+              ""history_data_sharing_status"": ""DISABLED"",
+              ""start_version"": 0,
+              ""status"": ""ACTIVE"",
+              ""content"": ""string"",
+              ""string_shared_as"": ""string""
+            }
+          ],
+          ""created_at"": 0,
+          ""created_by"": ""string"",
+          ""updated_at"": 0,
+          ""updated_by"": ""string"",
+          ""storage_location"": ""string""
+        }
+        ";
+
+        var requestUri = SharesApiUri;
+        var shareToCreate = JsonSerializer.Deserialize<ShareAttributes>(expectedRequest, Options);
+
+        var handler = CreateMockHandler();
+        handler
+            .SetupRequest(HttpMethod.Post, requestUri)
+            .ReturnsResponse(HttpStatusCode.OK, expectedResponse, "application/json");
+
+        var mockClient = handler.CreateClient();
+        mockClient.BaseAddress = ApiClientTest.BaseApiUri;
+
+        using var client = new SharesApiClient(mockClient);
+
+        var response = await client.Create(shareToCreate);
+        var responseJson = JsonSerializer.Serialize(response, Options);
+
+        AssertJsonDeepEquals(expectedResponse, responseJson);
+
+        handler.VerifyRequest(
+            HttpMethod.Post,
+            requestUri,
+            GetMatcher(expectedRequest),
+            Times.Once());
+    }
+
+    [TestMethod]
+    public async Task TestGet()
+    {
+        var shareName = "share123";
+        var includeSharedData = true;
+        var requestUri = $"{SharesApiUri}/{shareName}?include_shared_data={includeSharedData.ToString().ToLower()}";
+
+        var expectedReponse = @"
+        {
+          ""name"": ""string"",
+          ""owner"": ""string"",
+          ""comment"": ""string"",
+          ""storage_root"": ""string"",
+          ""objects"": [
+            {
+              ""name"": ""string"",
+              ""data_object_type"": ""TABLE"",
+              ""added_at"": 0,
+              ""added_by"": ""string"",
+              ""comment"": ""string"",
+              ""shared_as"": ""string"",
+              ""partitions"": [
+                {
+                  ""values"": [
+                    {
+                      ""name"": ""string"",
+                      ""value"": ""string"",
+                      ""recipient_property_key"": ""string"",
+                      ""op"": ""EQUAL""
+                    }
+                  ]
+                }
+              ],
+              ""cdf_enabled"": true,
+              ""history_data_sharing_status"": ""DISABLED"",
+              ""start_version"": 0,
+              ""status"": ""ACTIVE"",
+              ""content"": ""string"",
+              ""string_shared_as"": ""string""
+            }
+          ],
+          ""created_at"": 0,
+          ""created_by"": ""string"",
+          ""updated_at"": 0,
+          ""updated_by"": ""string"",
+          ""storage_location"": ""string""
+        }
+        ";
+
+        var handler = CreateMockHandler();
+        handler
+            .SetupRequest(HttpMethod.Get, requestUri)
+            .ReturnsResponse(HttpStatusCode.OK, expectedReponse, "application/json");
+
+        var mockClient = handler.CreateClient();
+        mockClient.BaseAddress = ApiClientTest.BaseApiUri;
+
+        using var client = new SharesApiClient(mockClient);
+
+        var actual = await client.Get(shareName, includeSharedData: includeSharedData);
+        var actualJson = JsonSerializer.Serialize(actual, Options);
+        AssertJsonDeepEquals(expectedReponse, actualJson);
+    }
+
+    [TestMethod]
+    public async Task TestUpdate()
+    {
+        var shareName = "share123";
+        var requestUri = $"{SharesApiUri}/{shareName}";
+
+        // new values, same as in expected request
+        var newName = "string";
+        var owner = "string";
+        var comment = "string";
+        var storage_root = "string";
+        var updates = new []
+        {
+            new ShareObjectUpdate
+            {
+                Action = ShareObjectUpdateAction.ADD,
+                Object = new ShareObject
+                {
+                    Name = "string",
+                    DataObjectType = DataObjectType.TABLE,
+                    AddedAt = 0,
+                    AddedBy = "string",
+                    Comment = "string",
+                    SharedAs = "string",
+                    Partitions =
+                    [
+                        new SharePartition
+                        {
+                            Values =
+                            [
+                                new SharePartitionValue
+                                {
+                                    Name = "string",
+                                    Value = "string",
+                                    RecipientPropertyKey = "string",
+                                    Op = "EQUAL"
+                                }
+                            ]
+                        }
+                    ],
+                    CdfEnabled = true,
+                    HistoryDataSharingStatus = HistoryDataSharingStatus.DISABLED,
+                    StartVersion = 0,
+                    Status = Status.ACTIVE,
+                    Content = "string",
+                    StringSharedAs = "string"
+                }
+            }
+        };
+
+        var expectedRequest = @"
+        {
+          ""new_name"": ""string"",
+          ""updates"": [
+            {
+              ""action"": ""ADD"",
+              ""data_object"": {
+                ""name"": ""string"",
+                ""data_object_type"": ""TABLE"",
+                ""added_at"": 0,
+                ""added_by"": ""string"",
+                ""comment"": ""string"",
+                ""shared_as"": ""string"",
+                ""partitions"": [
+                  {
+                    ""values"": [
+                      {
+                        ""name"": ""string"",
+                        ""value"": ""string"",
+                        ""recipient_property_key"": ""string"",
+                        ""op"": ""EQUAL""
+                      }
+                    ]
+                  }
+                ],
+                ""cdf_enabled"": true,
+                ""history_data_sharing_status"": ""DISABLED"",
+                ""start_version"": 0,
+                ""status"": ""ACTIVE"",
+                ""content"": ""string"",
+                ""string_shared_as"": ""string""
+              }
+            }
+          ],
+          ""owner"": ""string"",
+          ""comment"": ""string"",
+          ""storage_root"": ""string""
+        }
+        ";
+
+        var expectedResponse = @"
+        {
+          ""name"": ""string"",
+          ""owner"": ""string"",
+          ""comment"": ""string"",
+          ""storage_root"": ""string"",
+          ""objects"": [
+            {
+              ""name"": ""string"",
+              ""data_object_type"": ""TABLE"",
+              ""added_at"": 0,
+              ""added_by"": ""string"",
+              ""comment"": ""string"",
+              ""shared_as"": ""string"",
+              ""partitions"": [
+                {
+                  ""values"": [
+                    {
+                      ""name"": ""string"",
+                      ""value"": ""string"",
+                      ""recipient_property_key"": ""string"",
+                      ""op"": ""EQUAL""
+                    }
+                  ]
+                }
+              ],
+              ""cdf_enabled"": true,
+              ""history_data_sharing_status"": ""DISABLED"",
+              ""start_version"": 0,
+              ""status"": ""ACTIVE"",
+              ""content"": ""string"",
+              ""string_shared_as"": ""string""
+            }
+          ],
+          ""created_at"": 0,
+          ""created_by"": ""string"",
+          ""updated_at"": 0,
+          ""updated_by"": ""string"",
+          ""storage_location"": ""string""
+        }
+        ";
+
+        var handler = CreateMockHandler();
+        handler
+            .SetupRequest(HttpMethod.Patch, requestUri)
+            .ReturnsResponse(HttpStatusCode.OK, expectedResponse, "application/json");
+
+        var mockClient = handler.CreateClient();
+        mockClient.BaseAddress = ApiClientTest.BaseApiUri;
+
+        using var client = new SharesApiClient(mockClient);
+        var response = await client.Update(shareName, newName, owner, comment, storage_root, updates);
+
+        var responseJson = JsonSerializer.Serialize(response, Options);
+        AssertJsonDeepEquals(expectedResponse, responseJson);
+
+        handler.VerifyRequest(
+            HttpMethod.Patch,
+            requestUri,
+            GetMatcher(expectedRequest),
+            Times.Once());
+    }
+
+    [TestMethod]
+    public async Task TestDelete()
+    {
+        var shareName = "share123";
+        var requestUri = $"{SharesApiUri}/{shareName}";
+
+        var handler = CreateMockHandler();
+        handler
+            .SetupRequest(HttpMethod.Delete, requestUri)
+            .ReturnsResponse(HttpStatusCode.OK);
+
+        var mockClient = handler.CreateClient();
+        mockClient.BaseAddress = ApiClientTest.BaseApiUri;
+
+        using var client = new SharesApiClient(mockClient);
+        await client.Delete(shareName);
+
+        handler.VerifyRequest(
+            HttpMethod.Delete,
+            requestUri);
+    }
+
+    [TestMethod]
+    public async Task TestGetPermissions()
+    {
+        var shareName = "share123";
+        var requestUri = $"{SharesApiUri}/{shareName}/permissions";
+
+        var expectedReponse = @"
+        {
+          ""privilege_assignments"": [
+            {
+              ""principal"": ""string"",
+              ""privileges"": [
+                ""SELECT""
+              ]
+            }
+          ]
+        }
+        ";
+
+        var handler = CreateMockHandler();
+        handler
+            .SetupRequest(HttpMethod.Get, requestUri)
+            .ReturnsResponse(HttpStatusCode.OK, expectedReponse, "application/json");
+
+        var mockClient = handler.CreateClient();
+        mockClient.BaseAddress = ApiClientTest.BaseApiUri;
+
+        using var client = new SharesApiClient(mockClient);
+
+        var actual = await client.GetPermissions(shareName);
+        var responseObj = new { privilege_assignments = actual };
+        var actualJson = JsonSerializer.Serialize(responseObj, Options);
+
+        AssertJsonDeepEquals(expectedReponse, actualJson);
+    }
+
+    [TestMethod]
+    public async Task TestUpdatePermissions()
+    {
+        var shareName = "share123";
+        var requestUri = $"{SharesApiUri}/{shareName}/permissions";
+
+        // new values, same as in expected request
+        var changes = new []
+        {
+            new PermissionsUpdate
+            {
+                Principal = "string",
+                Add = [Privilege.SELECT],
+                Remove = [Privilege.USAGE],
+            }
+        };
+
+        var expectedRequest = @"
+        {
+          ""changes"": [
+            {
+              ""principal"": ""string"",
+              ""add"": [
+                ""SELECT""
+              ],
+              ""remove"": [
+                ""USAGE""
+              ]
+            }
+          ]
+        }
+        ";
+
+        var expectedResponse = @"
+        {
+          ""privilege_assignments"": [
+            {
+              ""principal"": ""string"",
+              ""privileges"": [
+                ""SELECT""
+              ]
+            }
+          ]
+        }
+        ";
+
+        var handler = CreateMockHandler();
+        handler
+            .SetupRequest(HttpMethod.Patch, requestUri)
+            .ReturnsResponse(HttpStatusCode.OK, expectedResponse, "application/json");
+
+        var mockClient = handler.CreateClient();
+        mockClient.BaseAddress = ApiClientTest.BaseApiUri;
+
+        using var client = new SharesApiClient(mockClient);
+        var actual = await client.UpdatePermissions(shareName, changes);
+        var responseObj = new { privilege_assignments = actual };
+        var actualJson = JsonSerializer.Serialize(responseObj, Options);
+
+        AssertJsonDeepEquals(expectedResponse, actualJson);
+
+        handler.VerifyRequest(
+            HttpMethod.Patch,
+            requestUri,
+            GetMatcher(expectedRequest),
+            Times.Once());
+    }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client.Test/UnityCatalog/SharesApiClientTest.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client.Test/UnityCatalog/SharesApiClientTest.cs
@@ -67,7 +67,7 @@ public class SharesApiClientTest : UnityCatalogApiClientTest
 
         var handler = CreateMockHandler();
         handler
-            .SetupRequest(HttpMethod.Get, requestUri)
+            .SetupRequest(HttpMethod.Get, x => SharesApiUri.IsBaseOf(x.RequestUri!))
             .ReturnsResponse(HttpStatusCode.OK, expectedResponse, "application/json");
 
         var mockClient = handler.CreateClient();
@@ -75,8 +75,7 @@ public class SharesApiClientTest : UnityCatalogApiClientTest
 
         using var client = new SharesApiClient(mockClient);
         var actual = await client.List();
-        var responseObj = new { shares = actual };
-        var responseJson = JsonSerializer.Serialize(responseObj, Options);
+        var responseJson = JsonSerializer.Serialize(actual, Options);
 
         AssertJsonDeepEquals(expectedResponse, responseJson);
     }
@@ -243,7 +242,7 @@ public class SharesApiClientTest : UnityCatalogApiClientTest
                 {
                     Name = "string",
                     DataObjectType = DataObjectType.TABLE,
-                    AddedAt = 0,
+                    AddedAt = DateTimeOffset.FromUnixTimeMilliseconds(1727704621000),
                     AddedBy = "string",
                     Comment = "string",
                     SharedAs = "string",
@@ -266,7 +265,7 @@ public class SharesApiClientTest : UnityCatalogApiClientTest
                     CdfEnabled = true,
                     HistoryDataSharingStatus = HistoryDataSharingStatus.DISABLED,
                     StartVersion = 0,
-                    Status = Status.ACTIVE,
+                    Status = ShareObjectStatus.ACTIVE,
                     Content = "string",
                     StringSharedAs = "string"
                 }
@@ -282,7 +281,7 @@ public class SharesApiClientTest : UnityCatalogApiClientTest
               ""data_object"": {
                 ""name"": ""string"",
                 ""data_object_type"": ""TABLE"",
-                ""added_at"": 0,
+                ""added_at"": 1727704621000,
                 ""added_by"": ""string"",
                 ""comment"": ""string"",
                 ""shared_as"": ""string"",
@@ -419,7 +418,7 @@ public class SharesApiClientTest : UnityCatalogApiClientTest
 
         var handler = CreateMockHandler();
         handler
-            .SetupRequest(HttpMethod.Get, requestUri)
+            .SetupRequest(HttpMethod.Get, x => SharesApiUri.IsBaseOf(x.RequestUri!))
             .ReturnsResponse(HttpStatusCode.OK, expectedReponse, "application/json");
 
         var mockClient = handler.CreateClient();
@@ -428,8 +427,7 @@ public class SharesApiClientTest : UnityCatalogApiClientTest
         using var client = new SharesApiClient(mockClient);
 
         var actual = await client.GetPermissions(shareName);
-        var responseObj = new { privilege_assignments = actual };
-        var actualJson = JsonSerializer.Serialize(responseObj, Options);
+        var actualJson = JsonSerializer.Serialize(actual, Options);
 
         AssertJsonDeepEquals(expectedReponse, actualJson);
     }

--- a/csharp/Microsoft.Azure.Databricks.Client.Test/UnityCatalog/SharesApiClientTest.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client.Test/UnityCatalog/SharesApiClientTest.cs
@@ -233,7 +233,7 @@ public class SharesApiClientTest : UnityCatalogApiClientTest
         var owner = "string";
         var comment = "string";
         var storage_root = "string";
-        var updates = new []
+        var updates = new[]
         {
             new ShareObjectUpdate
             {
@@ -439,7 +439,7 @@ public class SharesApiClientTest : UnityCatalogApiClientTest
         var requestUri = $"{SharesApiUri}/{shareName}/permissions";
 
         // new values, same as in expected request
-        var changes = new []
+        var changes = new[]
         {
             new PermissionsUpdate
             {

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/PermissionsList.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/PermissionsList.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Azure.Databricks.Client.Models.UnityCatalog;
+
+public class PermissionsList
+{
+    public PermissionsList()
+    {
+        this.Permissions = new List<Permission>();
+    }
+
+    /// <summary>
+    /// The privileges assigned to each principal
+    /// </summary>
+    [JsonPropertyName("privilege_assignments")]
+    public IEnumerable<Permission> Permissions { get; set; }
+
+    /// <summary>
+    /// Opaque token to retrieve the next page of results. Absent if there are no more pages. page_token should be set to this value for the next request (for the next page of results).
+    /// </summary>
+    [JsonPropertyName("next_page_token")]
+    public string NextPageToken { get; set; }
+
+    [JsonIgnore]
+    public bool HasMore => !string.IsNullOrEmpty(this.NextPageToken);
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/Share.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/Share.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Azure.Databricks.Client.Models.UnityCatalog;
+
+public record Share : ShareAttributes
+{
+    /// <summary>
+    /// Username of current owner of share.
+    /// </summary>
+    [JsonPropertyName("owner")]
+    public string Owner { get; set; }
+
+    /// <summary>
+    /// A list of shared data objects within the share.
+    /// </summary>
+    [JsonPropertyName("objects")]
+    public IEnumerable<ShareObject> Objects { get; set; }
+
+    /// <summary>
+    /// Time at which this share was created, in epoch milliseconds.
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public DateTimeOffset? CreatedAt { get; set; }
+
+    /// <summary>
+    /// Username of share creator.
+    /// </summary>
+    [JsonPropertyName("created_by")]
+    public string CreatedBy { get; set; }
+
+    /// <summary>
+    /// Time at which this share was last modified, in epoch milliseconds.
+    /// </summary>
+    [JsonPropertyName("updated_at")]
+    public DateTimeOffset? UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Username of user who last modified share.
+    /// </summary>
+    [JsonPropertyName("updated_by")]
+    public string UpdatedBy { get; set; }
+
+    /// <summary>
+    /// Storage Location URL (full path) for the share.
+    /// </summary>
+    [JsonPropertyName("storage_location")]
+    public string StorageLocation { get; set; }
+}
+
+public record ShareObject
+{
+    /// <summary>
+    /// A fully qualified name that uniquely identifies a data object.
+    /// For example, a table's fully qualified name is in the format of catalog.schema.table.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// A user-provided comment when adding the data object to the share.
+    /// </summary>
+    [JsonPropertyName("comment")]
+    public string Comment { get; set; }
+
+    /// <summary>
+    /// A user-provided new name for the data object within the share.
+    /// If this new name is not provided, the object's original name will be used as the shared_as name.
+    /// The shared_as name must be unique within a share.
+    /// For tables, the new name must follow the format of schema.table.
+    /// </summary>
+    [JsonPropertyName("shared_as")]
+    public string SharedAs { get; set; }
+
+    /// <summary>
+    /// A user-provided new name for the data object within the share.
+    /// If this new name is not provided, the object's original name will be used as the string_shared_as name.
+    /// The string_shared_as name must be unique within a share.
+    /// For notebooks, the new name should be the new notebook file name.
+    /// </summary>
+    [JsonPropertyName("string_shared_as")]
+    public string StringSharedAs { get; set; }
+
+    /// <summary>
+    /// The content of the notebook file when the data object type is NOTEBOOK_FILE.
+    /// This should be base64 encoded.
+    /// Required for adding a NOTEBOOK_FILE, optional for updating, ignored for other types.
+    /// </summary>
+    [JsonPropertyName("content")]
+    public string Content { get; set; }
+
+    /// <summary>
+    /// Whether to enable or disable sharing of data history.
+    /// If not specified, the default is DISABLED.
+    /// </summary>
+    [JsonPropertyName("history_data_sharing_status")]
+    public HistoryDataSharingStatus? HistoryDataSharingStatus { get; set; }
+
+    /// <summary>
+    /// Array of partitions for the shared data.
+    /// </summary>
+    [JsonPropertyName("partitions")]
+    public IEnumerable<SharePartition> Partitions { get; set; }
+
+    /// <summary>
+    /// Whether to enable cdf or indicate if cdf is enabled on the shared object.
+    /// </summary>
+    [JsonPropertyName("cdf_enabled")]
+    public bool? CdfEnabled { get; set; }
+
+    /// <summary>
+    /// The start version associated with the object.
+    /// This allows data providers to control the lowest object version that is accessible by clients.
+    /// If specified, clients can query snapshots or changes for versions >= start_version.
+    /// If not specified, clients can only query starting from the version of the object at the time it was added to the share.
+    /// NOTE: The start_version should be less or equal the current version of the object.
+    /// </summary>
+    [JsonPropertyName("start_version")]
+    public long? StartVersion { get; set; }
+
+    /// <summary>
+    /// The type of the data object.
+    /// Enum: TABLE | SCHEMA | VIEW | MATERIALIZED_VIEW | STREAMING_TABLE | MODEL | NOTEBOOK_FILE | FUNCTION | FEATURE_SPEC
+    /// </summary>
+    [JsonPropertyName("data_object_type")]
+    public DataObjectType? DataObjectType { get; set; }
+
+    /// <summary>
+    /// The time when this data object is added to the share, in epoch milliseconds.
+    /// </summary>
+    [JsonPropertyName("added_at")]
+    public long? AddedAt { get; set; }
+
+    /// <summary>
+    /// Username of the sharer.
+    /// </summary>
+    [JsonPropertyName("added_by")]
+    public string AddedBy { get; set; }
+
+    /// <summary>
+    /// One of: ACTIVE, PERMISSION_DENIED.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public Status? Status { get; set; }
+}
+
+public enum DataObjectType
+{
+    TABLE,
+    SCHEMA,
+    VIEW,
+    MATERIALIZED_VIEW,
+    STREAMING_TABLE,
+    MODEL,
+    NOTEBOOK_FILE,
+    FUNCTION,
+    FEATURE_SPEC
+}
+
+public enum Status
+{
+    ACTIVE,
+    PERMISSION_DENIED
+}
+
+public enum HistoryDataSharingStatus
+{
+    ENABLED,
+    DISABLED
+}
+
+public enum ShareObjectUpdateAction
+{
+    ADD,
+    REMOVE,
+    UPDATE
+}
+
+public record ShareObjectUpdate
+{
+    /// <summary>
+    /// One of: ADD, REMOVE, UPDATE.
+    /// </summary>
+    [JsonPropertyName("action")]
+    public ShareObjectUpdateAction? Action { get; set; }
+
+    /// <summary>
+    /// The data object that is being added, removed, or updated.
+    /// </summary>
+    [JsonPropertyName("data_object")]
+    public ShareObject Object { get; set; }
+}
+
+public record SharePartition
+{
+    /// <summary>
+    /// An array of partition values.
+    /// </summary>
+    [JsonPropertyName("values")]
+    public IEnumerable<SharePartitionValue> Values { get; set; }
+}
+
+public record SharePartitionValue
+{
+    /// <summary>
+    /// The name of the partition column.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// The value of the partition column. When this value is not set, it means null value.
+    /// When this field is set, field recipient_property_key can not be set.
+    /// </summary>
+    [JsonPropertyName("value")]
+    public string Value { get; set; }
+
+    /// <summary>
+    /// The key of a Delta Sharing recipient's property. For example "databricks-account-id".
+    /// When this field is set, field value can not be set.
+    /// </summary>
+    [JsonPropertyName("recipient_property_key")]
+    public string RecipientPropertyKey { get; set; }
+
+    /// <summary>
+    /// The operator to apply for the value.
+    /// Enum: EQUAL | LIKE
+    /// </summary>
+    [JsonPropertyName("op")]
+    public string Op { get; set; }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/Share.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/Share.cs
@@ -127,10 +127,10 @@ public record ShareObject
     public DataObjectType? DataObjectType { get; set; }
 
     /// <summary>
-    /// The time when this data object is added to the share, in epoch milliseconds.
+    /// The time when this data object is added to the share.
     /// </summary>
     [JsonPropertyName("added_at")]
-    public long? AddedAt { get; set; }
+    public DateTimeOffset? AddedAt { get; set; }
 
     /// <summary>
     /// Username of the sharer.
@@ -142,7 +142,7 @@ public record ShareObject
     /// One of: ACTIVE, PERMISSION_DENIED.
     /// </summary>
     [JsonPropertyName("status")]
-    public Status? Status { get; set; }
+    public ShareObjectStatus? Status { get; set; }
 }
 
 public enum DataObjectType
@@ -158,7 +158,7 @@ public enum DataObjectType
     FEATURE_SPEC
 }
 
-public enum Status
+public enum ShareObjectStatus
 {
     ACTIVE,
     PERMISSION_DENIED

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/ShareAttributes.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/ShareAttributes.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Azure.Databricks.Client.Models.UnityCatalog;
+
+public record ShareAttributes
+{
+    /// <summary>
+    /// Name of catalog.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// User-provided free-form text description.
+    /// </summary>
+    [JsonPropertyName("comment")]
+    public string Comment { get; set; }
+
+    /// <summary>
+    /// Storage root URL for the share.
+    /// </summary>
+    [JsonPropertyName("storage_root")]
+    public string StorageRoot { get; set; }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/SharesList.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/UnityCatalog/SharesList.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Azure.Databricks.Client.Models.UnityCatalog;
+
+public class SharesList
+{
+    public SharesList()
+    {
+        this.Shares = new List<Share>();
+    }
+
+    /// <summary>
+    /// An array of data share information objects.
+    /// </summary>
+    [JsonPropertyName("shares")]
+    public IEnumerable<Share> Shares { get; set; }
+
+    /// <summary>
+    /// Opaque token to retrieve the next page of results. Absent if there are no more pages. page_token should be set to this value for the next request (for the next page of results).
+    /// </summary>
+    [JsonPropertyName("next_page_token")]
+    public string NextPageToken { get; set; }
+
+    [JsonIgnore]
+    public bool HasMore => !string.IsNullOrEmpty(this.NextPageToken);
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/UnityCatalog/Interfaces/ISharesApi.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/UnityCatalog/Interfaces/ISharesApi.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Azure.Databricks.Client.Models.UnityCatalog;
+
+namespace Microsoft.Azure.Databricks.Client.UnityCatalog.Interfaces;
+
+public interface ISharesApi
+{
+    /// <summary>
+    /// Gets an array of data object shares from the metastore.
+    /// The caller must be a metastore admin or the owner of the share.
+    /// There is no guarantee of a specific ordering of the elements in the array.
+    /// </summary>
+    Task<IEnumerable<Share>> List(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a new share for data objects.
+    /// Data objects can be added after creation with update.
+    /// The caller must be a metastore admin or have the CREATE_SHARE privilege on the metastore.
+    /// </summary>
+    Task<Share> Create(ShareAttributes share, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a data object share from the metastore.
+    /// The caller must be a metastore admin or the owner of the share.
+    /// </summary>
+    Task<Share> Get(string shareName, bool includeSharedData = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates the share with the changes and data objects in the request.
+    /// The caller must be the owner of the share or a metastore admin.
+    ///
+    /// When the caller is a metastore admin, only the owner field can be updated.
+    ///
+    /// In the case that the share name is changed, updateShare requires that the caller is both the share owner and a metastore admin.
+    ///
+    /// If there are notebook files in the share, the storage_root field cannot be updated.
+    ///
+    /// For each table that is added through this method, the share owner must also have SELECT privilege on the table.
+    /// This privilege must be maintained indefinitely for recipients to be able to access the table.
+    /// Typically, you should use a group as the share owner.
+    ///
+    /// Table removals through update do not require additional privileges.
+    /// </summary>
+    Task<Share> Update(
+        string shareName,
+        string newName = null,
+        string owner = null,
+        string comment = null,
+        string storageRoot = null,
+        IEnumerable<ShareObjectUpdate> updates = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a data object share from the metastore. The caller must be an owner of the share.
+    /// </summary>
+    Task Delete(string shareName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the permissions for a data share from the metastore.
+    /// The caller must be a metastore admin or the owner of the share.
+    /// </summary>
+    Task<IEnumerable<Permission>> GetPermissions(
+        string shareName,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates the permissions for a data share in the metastore.
+    /// The caller must be a metastore admin or an owner of the share.
+    ///
+    /// For new recipient grants, the user must also be the recipient owner or metastore admin.
+    /// recipient revocations do not require additional privileges.
+    /// </summary>
+    Task<IEnumerable<Permission>> UpdatePermissions(
+        string shareName,
+        IEnumerable<PermissionsUpdate> changes,
+        CancellationToken cancellationToken = default);
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/UnityCatalog/Interfaces/ISharesApi.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/UnityCatalog/Interfaces/ISharesApi.cs
@@ -12,8 +12,51 @@ public interface ISharesApi
     /// Gets an array of data object shares from the metastore.
     /// The caller must be a metastore admin or the owner of the share.
     /// There is no guarantee of a specific ordering of the elements in the array.
+    /// <param name="maxResults">
+    /// Maximum number of shares to return.
+    /// <list type="bullet">
+    /// <item>
+    /// <description>When set to 0, the page length is set to a server configured value (recommended).</description>
+    /// </item>
+    /// <item>
+    /// <description>When set to a value greater than 0, the page length is the minimum of this value and a server configured value.</description>
+    /// </item>
+    /// <item>
+    /// <description>When set to a value less than 0, an invalid parameter error is returned.</description>
+    /// </item>
+    /// <item>
+    /// <description>Note: The number of returned shares might be less than the specified max_results size, even zero. The only definitive indication that no further shares can be fetched is when the next_page_token is unset from the response.</description>
+    /// </item>
+    /// </list>
+    /// </param>
     /// </summary>
-    Task<IEnumerable<Share>> List(CancellationToken cancellationToken = default);
+    /// <param name="pageToken">Opaque pagination token to go to next page based on previous query.</param>
+    Task<SharesList> List(int maxResults = 0, string pageToken = default, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets an array of data object shares from the metastore.
+    /// The caller must be a metastore admin or the owner of the share.
+    /// There is no guarantee of a specific ordering of the elements in the array.
+    /// <param name="maxResultsPerPage">
+    /// Maximum number of shares to return.
+    /// <list type="bullet">
+    /// <item>
+    /// <description>When set to 0, the page length is set to a server configured value (recommended).</description>
+    /// </item>
+    /// <item>
+    /// <description>When set to a value greater than 0, the page length is the minimum of this value and a server configured value.</description>
+    /// </item>
+    /// <item>
+    /// <description>When set to a value less than 0, an invalid parameter error is returned.</description>
+    /// </item>
+    /// <item>
+    /// <description>Note: The number of returned shares might be less than the specified max_results size, even zero. The only definitive indication that no further shares can be fetched is when the next_page_token is unset from the response.</description>
+    /// </item>
+    /// </list>
+    /// </param>
+    /// </summary>
+    global::Azure.AsyncPageable<Share> ListPageable(int maxResultsPerPage = 0, CancellationToken cancellationToken = default);
+
 
     /// <summary>
     /// Creates a new share for data objects.
@@ -62,9 +105,49 @@ public interface ISharesApi
     /// Gets the permissions for a data share from the metastore.
     /// The caller must be a metastore admin or the owner of the share.
     /// </summary>
-    Task<IEnumerable<Permission>> GetPermissions(
-        string shareName,
-        CancellationToken cancellationToken = default);
+    /// <param name="maxResults">
+    /// Maximum number of shares to return.
+    /// <list type="bullet">
+    /// <item>
+    /// <description>When set to 0, the page length is set to a server configured value (recommended).</description>
+    /// </item>
+    /// <item>
+    /// <description>When set to a value greater than 0, the page length is the minimum of this value and a server configured value.</description>
+    /// </item>
+    /// <item>
+    /// <description>When set to a value less than 0, an invalid parameter error is returned.</description>
+    /// </item>
+    /// <item>
+    /// <description>Note: The number of returned shares might be less than the specified max_results size, even zero. The only definitive indication that no further shares can be fetched is when the next_page_token is unset from the response.</description>
+    /// </item>
+    /// </list>
+    /// </param>
+    /// <param name="pageToken">Opaque pagination token to go to next page based on previous query.</param>
+    Task<PermissionsList> GetPermissions(string shareName, int maxResults = 0, string pageToken = default, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the permissions for a data share from the metastore with pagination support.
+    /// The caller must be a metastore admin or the owner of the share.
+    /// </summary>
+    /// <param name="shareName">The name of the share.</param>
+    /// <param name="maxResultsPerPage">
+    /// Maximum number of shares to return.
+    /// <list type="bullet">
+    /// <item>
+    /// <description>When set to 0, the page length is set to a server configured value (recommended).</description>
+    /// </item>
+    /// <item>
+    /// <description>When set to a value greater than 0, the page length is the minimum of this value and a server configured value.</description>
+    /// </item>
+    /// <item>
+    /// <description>When set to a value less than 0, an invalid parameter error is returned.</description>
+    /// </item>
+    /// <item>
+    /// <description>Note: The number of returned shares might be less than the specified max_results size, even zero. The only definitive indication that no further shares can be fetched is when the next_page_token is unset from the response.</description>
+    /// </item>
+    /// </list>
+    /// </param>
+    global::Azure.AsyncPageable<Permission> GetPermissionsPageable(string shareName, int maxResultsPerPage = 0, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Updates the permissions for a data share in the metastore.

--- a/csharp/Microsoft.Azure.Databricks.Client/UnityCatalog/SharesApiClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/UnityCatalog/SharesApiClient.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Azure.Databricks.Client.Models.UnityCatalog;
+using Microsoft.Azure.Databricks.Client.UnityCatalog.Interfaces;
+
+namespace Microsoft.Azure.Databricks.Client.UnityCatalog;
+
+public class SharesApiClient : ApiClient, ISharesApi
+{
+    public SharesApiClient(HttpClient httpClient) : base(httpClient)
+    {
+    }
+
+    public async Task<IEnumerable<Share>> List(CancellationToken cancellationToken = default)
+    {
+        var requestUri = $"{BaseUnityCatalogUri}/shares";
+        var sharesList = await HttpGet<JsonObject>(this.HttpClient, requestUri, cancellationToken).ConfigureAwait(false);
+
+        sharesList.TryGetPropertyValue("shares", out var shares);
+
+        return shares?.Deserialize<IEnumerable<Share>>(Options) ?? Enumerable.Empty<Share>();
+    }
+
+    public async Task<Share> Create(ShareAttributes share, CancellationToken cancellationToken = default)
+    {
+        var requestUri = $"{BaseUnityCatalogUri}/shares";
+
+        return await HttpPost<ShareAttributes, Share>(this.HttpClient, requestUri, share, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<Share> Get(string shareName, bool includeSharedData = false, CancellationToken cancellationToken = default)
+    {
+        var requestUri = $"{BaseUnityCatalogUri}/shares/{shareName}?include_shared_data={includeSharedData.ToString().ToLower()}";
+        return await HttpGet<Share>(this.HttpClient, requestUri, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<Share> Update(string shareName, string newName = default, string owner = default, string comment = default,
+        string storageRoot = default, IEnumerable<ShareObjectUpdate> updates = default, CancellationToken cancellationToken = default)
+    {
+        var requestUri = $"{BaseUnityCatalogUri}/shares/{shareName}";
+        var request = new { new_name = newName, owner, comment, storage_root = storageRoot, updates };
+        return await HttpPatch<dynamic, Share>(HttpClient, requestUri, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task Delete(string shareName, CancellationToken cancellationToken = default)
+    {
+        var requestUri = $"{BaseUnityCatalogUri}/shares/{shareName}";
+        await HttpDelete(HttpClient, requestUri, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IEnumerable<Permission>> GetPermissions(string shareName, CancellationToken cancellationToken = default)
+    {
+        var requestUri = $"{BaseUnityCatalogUri}/shares/{shareName}/permissions";
+        var permissionsList = await HttpGet<JsonObject>(HttpClient, requestUri, cancellationToken).ConfigureAwait(false);
+        permissionsList.TryGetPropertyValue("privilege_assignments", out var permissions);
+
+        return permissions.Deserialize<IEnumerable<Permission>>(Options) ?? Enumerable.Empty<Permission>();
+    }
+
+    public async Task<IEnumerable<Permission>> UpdatePermissions(string shareName, IEnumerable<PermissionsUpdate> changes, CancellationToken cancellationToken = default)
+    {
+        var requestUri = $"{BaseUnityCatalogUri}/shares/{shareName}/permissions";
+        var request = new { changes };
+
+        var permissionsList = await HttpPatch<dynamic, JsonObject>(HttpClient, requestUri, request, cancellationToken).ConfigureAwait(false);
+        permissionsList.TryGetPropertyValue("privilege_assignments", out var permissions);
+
+        return permissions.Deserialize<IEnumerable<Permission>>(Options) ?? Enumerable.Empty<Permission>();
+    }
+}

--- a/csharp/Microsoft.Azure.Databricks.Client/UnityCatalogClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/UnityCatalogClient.cs
@@ -1,4 +1,6 @@
 using Microsoft.Azure.Databricks.Client.MachineLearning;
+
+
 using Microsoft.Azure.Databricks.Client.UnityCatalog;
 using Microsoft.Azure.Databricks.Client.UnityCatalog.Interfaces;
 using System;

--- a/csharp/Microsoft.Azure.Databricks.Client/UnityCatalogClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/UnityCatalogClient.cs
@@ -17,6 +17,7 @@ public class UnityCatalogClient : ApiClient, IDisposable
         this.Metastores = new MetastoresApiClient(httpClient);
         this.Schemas = new SchemasApiClient(httpClient);
         this.SecurableWorkspaceBindings = new SecurableWorkspaceBindingsApiClient(httpClient);
+        this.Shares = new SharesApiClient(httpClient);
         this.StorageCredentials = new StorageCredentialsApiClient(httpClient);
         this.SystemSchemas = new SystemSchemasApiClient(httpClient);
         this.TableConstraints = new TableConstraintsApiClient(httpClient);
@@ -41,6 +42,8 @@ public class UnityCatalogClient : ApiClient, IDisposable
     public virtual ISchemasApi Schemas { get; set; }
 
     public virtual ISecurableWorkspaceBindingsApi SecurableWorkspaceBindings { get; set; }
+
+    public virtual ISharesApi Shares { get; set; }
 
     public virtual IStorageCredentialsApi StorageCredentials { get; set; }
 

--- a/csharp/Microsoft.Azure.Databricks.Client/UnityCatalogClient.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/UnityCatalogClient.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Azure.Databricks.Client.MachineLearning;
+using Microsoft.Azure.Databricks.Client.MachineLearning;
 using Microsoft.Azure.Databricks.Client.UnityCatalog;
 using Microsoft.Azure.Databricks.Client.UnityCatalog.Interfaces;
 using System;


### PR DESCRIPTION
This PR adds support for Unity Catalog Shares API and closes https://github.com/Azure/azure-databricks-client/issues/258

* Implement all endpoints under [/api/2.1/unity-catalog/shares](https://docs.databricks.com/api/azure/workspace/shares)
* add unit tests 

@memoryz 