### PR TITLE
Add WarehouseId to NotebookTask

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/Models/Tasks.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/Tasks.cs
@@ -29,6 +29,14 @@ public record NotebookTask
     /// </summary>
     [JsonPropertyName("source")]
     public NotebookTaskSource Source { get; set; }
+
+    /// <summary>
+    /// Optional warehouse_id to run the notebook on a SQL warehouse. 
+    /// Classic SQL warehouses are NOT supported, please use serverless or pro SQL warehouses.
+    /// Note that SQL warehouses only support SQL cells; if the notebook contains non-SQL cells, the run will fail.
+    /// </summary>
+    [JsonPropertyName("warehouse_id")]
+    public string WarehouseId { get; set; }
 }
 
 public enum NotebookTaskSource


### PR DESCRIPTION
Fixes #285

Adds `WarehouseId` property to `NotebookTask` to run SQL notebooks on a SQL warehouse.

Let me know if I should include this property in the serialization tests.

I have tested the change against my Databricks workspace, and it does work. Here's a sample snippet I've used for testing. It simply creates and triggers a one-time run with a single notebook task configured to run on a SQL warehouse.

```csharp
using Microsoft.Azure.Databricks.Client;
using Microsoft.Azure.Databricks.Client.Models;

const string workspaceUrl = "https://abc-123-456-789.cloud.databricks.com/";
const string apiToken = "<api_token>";

const string notebookPath = "/Workspace/Users/user@example.com/sql_notebook";
const string warehouseId = "123456789abcdefg";

var client = DatabricksClient.CreateClient(workspaceUrl, apiToken);

var settings = new RunSubmitSettings { RunName = "TestJobRun" };

_ = settings.AddTask(
    "TestTaskRun",
    new NotebookTask
    {
        NotebookPath = notebookPath,
        BaseParameters = [],
        WarehouseId = warehouseId
    });

var runId = await client.Jobs.RunSubmit(settings);

Console.WriteLine($"Job run ID: {runId}");

while (true)
{
    var (run, _) = await client.Jobs.RunsGet(runId);
    Console.WriteLine($"Run status: {run.Status.State}");
    if (run.Status.State == RunStatusState.TERMINATED)
    {
        break;
    }
    await Task.Delay(TimeSpan.FromSeconds(5));
}
```