### PR TITLE
Add SYMLINK to ObjectType enum

### DIFF
--- a/csharp/Microsoft.Azure.Databricks.Client/Models/ObjectType.cs
+++ b/csharp/Microsoft.Azure.Databricks.Client/Models/ObjectType.cs
@@ -41,6 +41,11 @@ public enum ObjectType
     /// <summary>
     /// Lakeview Dashboard
     /// </summary>
-    DASHBOARD
+    DASHBOARD,
+
+    /// <summary>
+    /// Symbolic Link
+    /// </summary>
+    SYMLINK
 
 }


### PR DESCRIPTION
Add missing SYMLINK option to ObjectType enum. Have confirmed within Postman that this is the value being returned via the API